### PR TITLE
[iOS] Refactor View Hierarchy to Separate Side Menu and Tab Management Responsibilities

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
+++ b/swift/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B08824C2CE992A9001BEDB1 /* MainRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B08824B2CE992A4001BEDB1 /* MainRootViewController.swift */; };
 		3B20B0692C3D83E20045E904 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20B0682C3D83E20045E904 /* SearchResultViewController.swift */; };
 		3B20B06F2C3D89A70045E904 /* SearchResultTabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20B06E2C3D89A70045E904 /* SearchResultTabModel.swift */; };
 		3B30345E2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30345D2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift */; };
@@ -158,6 +159,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3B08824B2CE992A4001BEDB1 /* MainRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRootViewController.swift; sourceTree = "<group>"; };
 		3B20B0682C3D83E20045E904 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		3B20B06E2C3D89A70045E904 /* SearchResultTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTabModel.swift; sourceTree = "<group>"; };
 		3B30345D2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsVerifiedTabView.swift; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 				6540F8802BB44D430029BA46 /* AppDelegate.swift */,
 				6540F8822BB44D430029BA46 /* SceneDelegate.swift */,
 				658D08822BECF45F006C6A9E /* AppRootViewController.swift */,
+				3B08824B2CE992A4001BEDB1 /* MainRootViewController.swift */,
 				658D087C2BEBA068006C6A9E /* SideMenuView.swift */,
 				6540F8B32BB575580029BA46 /* Features */,
 				6540F8C32BB576C00029BA46 /* SDK */,
@@ -1107,6 +1110,7 @@
 				658D088E2BF3A02D006C6A9E /* CommunityModel.swift in Sources */,
 				6540F9052BD376A00029BA46 /* ExploreSettingsHeaderView.swift in Sources */,
 				3BFFDEA82CD1FF270072D369 /* TimelineSettingsHomeScreenTabsViewController.swift in Sources */,
+				3B08824C2CE992A9001BEDB1 /* MainRootViewController.swift in Sources */,
 				656C1BAE2C0216F600EEE575 /* NotificationsAllTabView.swift in Sources */,
 				65FD4FAF2C2AE0270020A02E /* NSNotification+Home.swift in Sources */,
 				658D08912BF4FD50006C6A9E /* MessagesSettingsHomeViewController.swift in Sources */,

--- a/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeTabView.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeTabView.swift
@@ -111,7 +111,7 @@ struct HomeTabView: View {
               if success {
                 let bannerController = BannerController(
                   message: String(format: LocalizedString.muteBannerTitle, userName))
-                bannerController.show(on: AppRootViewController.sharedInstance)
+                bannerController.show(on: MainRootViewController.sharedInstance)
               }
             }
           },

--- a/swift/Twitter-iOS/Twitter-iOS/Features/Post/PostShareBottomSheet.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Post/PostShareBottomSheet.swift
@@ -56,7 +56,7 @@ struct PostShareBottomSheet: View {
             isPostShareBottomSheetPresented.toggle()
             let bannerController = BannerController(
               message: String(localized: "Copied to clipboard"), bannerType: .TextOnly)
-            bannerController.show(on: AppRootViewController.sharedInstance)
+            bannerController.show(on: MainRootViewController.sharedInstance)
           } label: {
             VStack {
               Image(systemName: "link")

--- a/swift/Twitter-iOS/Twitter-iOS/MainRootViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/MainRootViewController.swift
@@ -1,0 +1,95 @@
+import UIKit
+
+class MainRootViewController: UITabBarController {
+
+  // MARK: - Public Props
+
+  public static var sharedInstance = MainRootViewController()
+
+  // MARK: - Private Props
+
+  private enum TabBarItemTag: Int {
+    case home
+    case search
+    case communities
+    case notifications
+    case messages
+  }
+
+  // MARK: - View Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    setUpTabBar()
+    setUpSubviews()
+  }
+
+  // MARK: - Private API
+
+  private func setUpTabBar() {
+    tabBar.backgroundColor = .systemBackground
+  }
+
+  private func setUpSubviews() {
+    let notificationCenter = NotificationCenter.default
+
+    let homeViewController = HomeViewController()
+    let homeNavigationController = UINavigationController(
+      rootViewController: homeViewController)
+    homeNavigationController.tabBarItem = UITabBarItem(
+      title: "", image: UIImage(systemName: "house"), tag: TabBarItemTag.home.rawValue)
+    notificationCenter.addObserver(
+      self, selector: #selector(didTapHomeTabBarItem), name: .didTapHomeTabBarItem, object: nil)
+    notificationCenter.addObserver(
+      self, selector: #selector(didLongPressHomeTabBarItem), name: .didLongPressHomeTabBarItem,
+      object: nil)
+
+    let searchViewController = UINavigationController(
+      rootViewController: SearchHomeViewController())
+    searchViewController.tabBarItem = UITabBarItem(
+      title: "", image: UIImage(systemName: "magnifyingglass"), tag: TabBarItemTag.search.rawValue)
+
+    let communitiesViewController = UINavigationController(
+      rootViewController: CommunitiesHomeViewController())
+    communitiesViewController.tabBarItem = UITabBarItem(
+      title: "", image: UIImage(systemName: "person.2"), tag: TabBarItemTag.communities.rawValue)
+
+    let notificationsViewController = UINavigationController(
+      rootViewController: NotificationsViewController())
+    notificationsViewController.tabBarItem = UITabBarItem(
+      title: "", image: UIImage(systemName: "bell"), tag: TabBarItemTag.notifications.rawValue)
+
+    let messagesViewController = UINavigationController(
+      rootViewController: MessagesViewController())
+    messagesViewController.tabBarItem = UITabBarItem(
+      title: "", image: UIImage(systemName: "envelope"), tag: TabBarItemTag.messages.rawValue)
+
+    viewControllers = [
+      homeNavigationController, searchViewController, communitiesViewController,
+      notificationsViewController, messagesViewController,
+    ]
+
+    tabBar.addSubview(homeViewController.tabBarItemOverlayView)
+    let tabBarButton = tabBar.subviews[TabBarItemTag.home.rawValue]
+    let overlayView = homeViewController.tabBarItemOverlayView
+    NSLayoutConstraint.activate([
+      overlayView.topAnchor.constraint(equalTo: tabBarButton.topAnchor),
+      overlayView.leadingAnchor.constraint(equalTo: tabBarButton.leadingAnchor),
+      overlayView.bottomAnchor.constraint(equalTo: tabBarButton.bottomAnchor),
+      overlayView.trailingAnchor.constraint(equalTo: tabBarButton.trailingAnchor),
+    ])
+  }
+
+  // MARK: - NSNotification
+
+  @objc
+  private func didTapHomeTabBarItem() {
+    selectedIndex = TabBarItemTag.home.rawValue
+  }
+
+  @objc
+  private func didLongPressHomeTabBarItem() {
+    selectedIndex = TabBarItemTag.home.rawValue
+  }
+}

--- a/swift/Twitter-iOS/Twitter-iOS/SideMenuView.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/SideMenuView.swift
@@ -54,7 +54,7 @@ struct SideMenuView: View {
   private func Header() -> some View {
     Button(
       action: {
-        delegate?.didTapUserProfile()
+        delegate?.userProfileDidReceiveTap()
       },
       label: {
         Image(systemName: "person.circle.fill")
@@ -65,7 +65,7 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapUserProfile()
+        delegate?.userProfileDidReceiveTap()
       },
       label: {
         Text(userName)
@@ -76,7 +76,7 @@ struct SideMenuView: View {
     HStack {
       Button(
         action: {
-          delegate?.didTapUserFollowRelationsButton(userName: userName)
+          delegate?.userFollowRelationsButtonDidReceiveTap(userName: userName)
         },
         label: {
           Text("\(numOfFollowing) \(LocalizedString.following)")
@@ -85,7 +85,7 @@ struct SideMenuView: View {
 
       Button(
         action: {
-          delegate?.didTapUserFollowRelationsButton(userName: userName)
+          delegate?.userFollowRelationsButtonDidReceiveTap(userName: userName)
         },
         label: {
           Text("\(numOfFollowers) \(LocalizedString.followers)")
@@ -98,7 +98,7 @@ struct SideMenuView: View {
   private func MainMenu() -> some View {
     Button(
       action: {
-        delegate?.didTapUserProfile()
+        delegate?.userProfileDidReceiveTap()
       },
       label: {
         Image(systemName: "person")
@@ -112,7 +112,7 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapBookmarks()
+        delegate?.bookmarksDidReceiveTap()
       },
       label: {
         Image(systemName: "bookmark")
@@ -126,7 +126,7 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapJobs()
+        delegate?.jobsDidReceiveTap()
       },
       label: {
         Image(systemName: "handbag")
@@ -140,7 +140,7 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapLists()
+        delegate?.listsDidReceiveTap()
       },
       label: {
         Image(systemName: "list.clipboard")
@@ -167,7 +167,7 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapFollowerRequests()
+        delegate?.followerRequestsDidReceiveTap()
       },
       label: {
         Image(systemName: "person.badge.plus")
@@ -181,7 +181,6 @@ struct SideMenuView: View {
 
     Button(
       action: {
-        delegate?.didTapFollowerRequests()
       },
       label: {
         Image(systemName: "bitcoinsign.circle")
@@ -206,7 +205,7 @@ struct SideMenuView: View {
       }
       .padding()
       .onTapGesture {
-        delegate?.didTapSettingsAndPrivacy()
+        delegate?.settingsAndPrivacyDidReceiveTap()
       }
 
       HStack {
@@ -231,13 +230,13 @@ struct SideMenuView: View {
 }
 
 protocol SideMenuViewDelegate: AnyObject {
-  func didTapUserProfile()
-  func didTapBookmarks()
-  func didTapJobs()
-  func didTapLists()
-  func didTapFollowerRequests()
-  func didTapSettingsAndPrivacy()
-  func didTapUserFollowRelationsButton(userName: String)
+  func userProfileDidReceiveTap()
+  func bookmarksDidReceiveTap()
+  func jobsDidReceiveTap()
+  func listsDidReceiveTap()
+  func followerRequestsDidReceiveTap()
+  func settingsAndPrivacyDidReceiveTap()
+  func userFollowRelationsButtonDidReceiveTap(userName: String)
 }
 
 private let fakeUser = createFakeUser()


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/503

## Implementation Summary
This PR refactors the view hierarchy by assigning the responsibility of presenting and dismissing the side menu to `AppRootViewController`, while `MainRootViewController` is now responsible for managing navigation between views based on the selected tabs.

## Scope of Impact
The behavior of the app remains unchanged. Tapping buttons in the side menu displays the corresponding view, and selecting tabs at the bottom navigates to the appropriate home view.

## Particular points to check
Please review whether the refactoring approach is appropriate.

## Reference
https://github.com/user-attachments/assets/d63ce1f9-5e45-4862-b4e7-81d3879fb6b9

## Schedule
Until 11/23.