### PR TITLE
[iOS] Implement Tap Gesture on OverlayView to Dismiss Side Menu

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS/Features/Settings/Timeline/TimelineSettingsViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Settings/Timeline/TimelineSettingsViewController.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 import UIKit
 
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/523
+// - Fix Bug Where UINavigationBar Does Not Appear in TimelineSettingsViewController.
+
 class TimelineSettingsViewController: UIViewController {
 
   // MARK: - Private Props

--- a/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionAnimator.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionAnimator.swift
@@ -6,18 +6,19 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
   public var isPresenting: Bool = true
 
+  public var dimmingViewTapAction: (() -> Void)? = nil
+
   // MARK: - Private Props
 
   private enum LayoutConstant {
     static let sideMenuWidth: CGFloat = 300.0
-    static let overlayViewAlphaWhenPresented: CGFloat = 0.5
+    static let dimmingViewAlphaWhenPresented: CGFloat = 0.5
     static let duration: TimeInterval = 0.25
   }
 
-  private let overlayView: UIView = {
+  private let dimmingView: UIView = {
     let view = UIView()
     view.backgroundColor = .black
-    view.alpha = 0.0
     return view
   }()
 
@@ -51,23 +52,28 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
     let containerView = transitionContext.containerView
 
-    overlayView.translatesAutoresizingMaskIntoConstraints = false
+    dimmingView.translatesAutoresizingMaskIntoConstraints = false
     toView.translatesAutoresizingMaskIntoConstraints = false
 
-    containerView.addSubview(overlayView)
+    containerView.addSubview(dimmingView)
     containerView.addSubview(toView)
 
     NSLayoutConstraint.activate([
-      overlayView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-      overlayView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-      overlayView.topAnchor.constraint(equalTo: containerView.topAnchor),
-      overlayView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+      dimmingView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+      dimmingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+      dimmingView.topAnchor.constraint(equalTo: containerView.topAnchor),
+      dimmingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
 
       toView.topAnchor.constraint(equalTo: containerView.topAnchor),
       toView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
       toView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
       toView.widthAnchor.constraint(equalToConstant: LayoutConstant.sideMenuWidth),
     ])
+
+    dimmingView.alpha = 0.0
+
+    let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onTapAction))
+    dimmingView.addGestureRecognizer(tapGestureRecognizer)
 
     toView.frame.origin.x = -LayoutConstant.sideMenuWidth
 
@@ -76,7 +82,7 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
       animations: { [weak self] in
         toView.frame.origin.x = 0.0
         fromView.frame.origin.x = LayoutConstant.sideMenuWidth
-        self?.overlayView.alpha = LayoutConstant.overlayViewAlphaWhenPresented
+        self?.dimmingView.alpha = LayoutConstant.dimmingViewAlphaWhenPresented
       },
       completion: { finished in
         let completed = finished && !transitionContext.transitionWasCancelled
@@ -99,11 +105,18 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
       animations: { [weak self] in
         toView.frame.origin.x = 0.0
         fromView.frame.origin.x = -LayoutConstant.sideMenuWidth
-        self?.overlayView.alpha = 0.0
+        self?.dimmingView.alpha = 0.0
       },
       completion: { finished in
         let completed = finished && !transitionContext.transitionWasCancelled
         transitionContext.completeTransition(completed)
       })
+  }
+
+  // MARK: - Tap Gesture Handling
+
+  @objc
+  private func onTapAction() {
+    dimmingViewTapAction?()
   }
 }

--- a/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionController.swift
@@ -1,8 +1,5 @@
 import UIKit
 
-// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/509
-// - Implement Tap Gesture on OverlayView to Dismiss Side Menu.
-
 // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/510
 // - Implement Swipe and Pan Gesture to Enable Manual Side Menu Transition.
 
@@ -13,6 +10,7 @@ class SideMenuTransitionController: NSObject, UIViewControllerTransitioningDeleg
   func animationController(
     forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController
   ) -> (any UIViewControllerAnimatedTransitioning)? {
+    animator.dimmingViewTapAction = { [weak presented] in presented?.dismiss(animated: true) }
     animator.isPresenting = true
     return animator
   }


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/509

## Implementation Summary
This PR introduces a tap gesture recognizer to the dimming view (formerly defined as the overlay view), enabling the tap-to-dismiss functionality for the side menu.

## Scope of Impact
When users tap the dimming view, the side menu will be dismissed.

## Particular points to check
Please check if the naming conventions in `DimmingView` are aligned with the intended functionalities.

## Reference
https://github.com/user-attachments/assets/3d3785ae-d6ca-4447-86bd-0f8f802f3676

## Schedule
Until 12/7.