### PR TITLE
[TS] Implement notifications UI at notifications page

### DIFF
--- a/ts/twitter/src/app/home/__test__/home.spec.tsx
+++ b/ts/twitter/src/app/home/__test__/home.spec.tsx
@@ -41,6 +41,8 @@ jest.mock("next/navigation", () => ({
 }));
 
 describe("Home Tests", () => {
+  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/522
+  // - Fix test descriptions in home.spec.tsx and post-modal.tsx.
   test("Rendering Home should success", () => {
     waitFor(() => {
       render(<Home />, { wrapper: SessionProvider });

--- a/ts/twitter/src/app/notifications/__test__/notifications.spec.tsx
+++ b/ts/twitter/src/app/notifications/__test__/notifications.spec.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react";
+import { Notifications } from "../_components/notifications";
+
+describe("Notifications Tests", () => {
+  test("Rendering Notifications should succeed", () => {
+    render(<Notifications />);
+  });
+});

--- a/ts/twitter/src/app/notifications/_components/notifications-all-view.tsx
+++ b/ts/twitter/src/app/notifications/_components/notifications-all-view.tsx
@@ -1,0 +1,15 @@
+import { Text, VStack } from "@chakra-ui/react";
+
+export function NotificationsAllView() {
+  return (
+    <VStack spacing={4} p={8} textAlign="center">
+      <Text fontSize="3xl" fontWeight="bold" lineHeight="shorter">
+        Nothing to see here — yet
+      </Text>
+      <Text fontSize="md">
+        From likes to reposts and a whole lot more, this is where all the action
+        happens.
+      </Text>
+    </VStack>
+  );
+}

--- a/ts/twitter/src/app/notifications/_components/notifications-mentions-view.tsx
+++ b/ts/twitter/src/app/notifications/_components/notifications-mentions-view.tsx
@@ -1,0 +1,12 @@
+import { Text, VStack } from "@chakra-ui/react";
+
+export function NotificationsMentionsView() {
+  return (
+    <VStack spacing={4} p={8} textAlign="center">
+      <Text fontSize="3xl" fontWeight="bold" lineHeight="shorter">
+        Nothing to see here — yet
+      </Text>
+      <Text fontSize="md">When someone mentions you, you'll find it here.</Text>
+    </VStack>
+  );
+}

--- a/ts/twitter/src/app/notifications/_components/notifications-tab-bar.tsx
+++ b/ts/twitter/src/app/notifications/_components/notifications-tab-bar.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {
+  Tabs,
+  TabIndicator,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Divider,
+} from "@chakra-ui/react";
+import { CustomTab } from "@/lib/components/custom-tab";
+import { NotificationsAllView } from "./notifications-all-view";
+import { NotificationsVerifiedView } from "./notifications-verified-view";
+import { NotificationsMentionsView } from "./notifications-mentions-view";
+
+export const NotificationsTabBar: React.FC = () => {
+  return (
+    <Tabs position="relative" variant="unstyled">
+      <TabList>
+        <CustomTab tabWidth={"100%"} message={"All"} fontSize={"lg"} />
+        <CustomTab tabWidth={"100%"} message={"Verified"} fontSize={"lg"} />
+        <CustomTab tabWidth={"100%"} message={"Mentions"} fontSize={"lg"} />
+      </TabList>
+      <Divider />
+      <TabIndicator mt="-1.5px" height="2px" bg="blue.500" borderRadius="1px" />
+      <TabPanels>
+        <TabPanel>
+          <NotificationsAllView />
+        </TabPanel>
+        <TabPanel>
+          <NotificationsVerifiedView />
+        </TabPanel>
+        <TabPanel>
+          <NotificationsMentionsView />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};

--- a/ts/twitter/src/app/notifications/_components/notifications-verified-view.tsx
+++ b/ts/twitter/src/app/notifications/_components/notifications-verified-view.tsx
@@ -1,0 +1,16 @@
+import { Text, VStack } from "@chakra-ui/react";
+
+export function NotificationsVerifiedView() {
+  return (
+    <VStack spacing={6} p={8} textAlign="center" alignItems="center">
+      <Text fontSize="3xl" fontWeight="bold" lineHeight="shorter">
+        Nothing to see here — yet
+      </Text>
+
+      <Text fontSize="md" maxW="500px">
+        Likes, mentions, reposts, and a whole lot more — when it comes from a
+        verified account, you'll find it here. Learn more
+      </Text>
+    </VStack>
+  );
+}

--- a/ts/twitter/src/app/notifications/_components/notifications.tsx
+++ b/ts/twitter/src/app/notifications/_components/notifications.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Box, Flex } from "@chakra-ui/react";
+import { SettingsButton } from "@/lib/components/settings-button";
+import { NotificationsTabBar } from "./notifications-tab-bar";
+
+export const Notifications: React.FC = () => {
+  return (
+    <Box>
+      <Flex>
+        <Box mx="12px" mt="8px" gap="4" fontSize="lg">
+          Notifications
+        </Box>
+        <SettingsButton />
+      </Flex>
+      <NotificationsTabBar />
+    </Box>
+  );
+};

--- a/ts/twitter/src/app/notifications/page.tsx
+++ b/ts/twitter/src/app/notifications/page.tsx
@@ -1,3 +1,5 @@
+import { Notifications } from "./_components/notifications";
+
 export default function Page() {
-  return <>notifications page</>;
+  return <Notifications />;
 }

--- a/ts/twitter/src/lib/components/settings-button.tsx
+++ b/ts/twitter/src/lib/components/settings-button.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { IconButton, Tooltip } from "@chakra-ui/react";
+import { IoIosSettings } from "react-icons/io";
+
+export const SettingsButton = () => {
+  return (
+    <Tooltip label="Settings" placement="bottom" size="sm">
+      <IconButton
+        bg="transparent"
+        aria-label="Settings"
+        icon={<IoIosSettings />}
+        mx={4}
+        size="lg"
+        borderRadius="full"
+        ml="auto"
+      />
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/517

## Implementation Summary
I implemented the notifications page. It displays a page indicating there are no notifications.
The implementation for when notifications exist is not included in this PR.

## References

https://github.com/user-attachments/assets/660a70e7-91e1-4ff6-b08f-e8604a633b53

## Test
`src/app/home/__test__/notifications.spec.tsx`
1. Start the frontend server (in the Twitter-Clone directory)
```
$ docker compose up -d
```
2. Enter the application container and run all test files
```
$ docker compose exec app bash
$ yarn test
```
　Use `--coverage` flag to generate coverage report

## Schedule
2024/12/6
