### PR TITLE
[iOS] Fix Bug Where UINavigationBar Does Not Appear in TimelineSettingsViewController

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeViewController.swift
@@ -34,7 +34,7 @@ class HomeViewController: ViewControllerWithUserIconButton {
 
   private lazy var timelineSettingsEntryPointButton: UIBarButtonItem = {
     let button = UIBarButtonItem(
-      title: "", style: .plain, target: self, action: #selector(presentExploreSettings))
+      title: "", style: .plain, target: self, action: #selector(presentTimelineSettings))
     button.tintColor = .black
     button.image = UIImage(systemName: "gear")
     return button
@@ -105,17 +105,21 @@ class HomeViewController: ViewControllerWithUserIconButton {
     navigationItem.titleView = UIImageView(image: UIImage(systemName: "apple.logo"))
   }
 
-  private func showTimelineSettings() {
-    let timelineSettingsViewController = TimelineSettingsViewController()
-    timelineSettingsViewController.modalPresentationStyle = .fullScreen
-    present(timelineSettingsViewController, animated: true)
-  }
-
   @objc
-  private func presentExploreSettings() {
-    let timelineSettingsViewController = TimelineSettingsViewController()
-    timelineSettingsViewController.modalPresentationStyle = .fullScreen
-    present(timelineSettingsViewController, animated: true)
+  private func presentTimelineSettings() {
+    let settingsHomeViewController = SettingsHomeViewController()
+    let presentingViewController = UINavigationController(
+      rootViewController: settingsHomeViewController)
+    let backButtonImage = UIImage(systemName: "arrow.left")
+    presentingViewController.navigationBar.backIndicatorImage = backButtonImage
+    presentingViewController.navigationBar.backIndicatorTransitionMaskImage = backButtonImage
+    presentingViewController.navigationBar.tintColor = .black
+
+    settingsHomeViewController.navigationItem.backButtonDisplayMode = .minimal
+    presentingViewController.pushViewController(
+      TimelineSettingsViewController(), animated: false)
+    presentingViewController.modalPresentationStyle = .fullScreen
+    present(presentingViewController, animated: true)
   }
 
   // MARK: - UITabBarItem

--- a/swift/Twitter-iOS/Twitter-iOS/Features/Settings/Timeline/TimelineSettingsViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Settings/Timeline/TimelineSettingsViewController.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 import UIKit
 
-// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/523
-// - Fix Bug Where UINavigationBar Does Not Appear in TimelineSettingsViewController.
-
 class TimelineSettingsViewController: UIViewController {
 
   // MARK: - Private Props
@@ -55,6 +52,7 @@ class TimelineSettingsViewController: UIViewController {
   // MARK: - Private API
 
   private func setUpSubviews() {
+    view.backgroundColor = .systemBackground
     view.addSubview(hostingController.view)
 
     let layoutGuide = view.safeAreaLayoutGuide


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/523

## Implementation Summary
This PR fixes a bug where the `UINavigationBar` was not appearing in the `TimelineSettingsViewController`. Now, the `UINavigationBar` is correctly displayed when the view is presented.

## Scope of Impact
The `TimelineSettingsViewController` will now display with a `UINavigationBar` when users tap the settings button in the upper-right corner of the view.

## Particular points to check
Please review whether the way the `TimelineSettingsViewController` is presented is appropriate.

## References
https://github.com/user-attachments/assets/c4755a6d-2381-45f2-a7a2-db9d4486fcf4

## Schedule
Until 12/14.
