### PR TITLE
[TS] Display an error message to users if post creation fails

### DIFF
--- a/ts/twitter/src/app/@modal/(.)compose/post/__test__/post-modal.spec.tsx
+++ b/ts/twitter/src/app/@modal/(.)compose/post/__test__/post-modal.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { PostModal } from "../_components/post-modal/post-modal";
 import { SessionProvider } from "@/lib/components/session-context";
 
@@ -8,6 +8,16 @@ jest.mock("next/navigation", () => ({
   },
 }));
 
+jest.mock("react-dom", () => {
+  return {
+    ...jest.requireActual("react-dom"),
+    useFormState: () => ["message", jest.fn()],
+    useFormStatus: () => ({
+      pending: true,
+    }),
+  };
+});
+
 describe("Post Modal Tests", () => {
   test("Rendering intercepted Post Modal should success", () => {
     render(<PostModal isIntercepted={true} />, { wrapper: SessionProvider });
@@ -15,5 +25,11 @@ describe("Post Modal Tests", () => {
 
   test("Rendering non-intercepted Post Modal should success", () => {
     render(<PostModal isIntercepted={false} />, { wrapper: SessionProvider });
+  });
+
+  test("Error message should be displayed when the form action fails", () => {
+    render(<PostModal isIntercepted={true} />, { wrapper: SessionProvider });
+    const errorMessage = screen.getByText("message");
+    expect(errorMessage).toBeInTheDocument();
   });
 });

--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-button/post-button.tsx
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-button/post-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@chakra-ui/react";
+import { useFormStatus } from "react-dom";
+
+export interface PostButtonProps {
+  isDisabled: boolean;
+}
+
+export const PostButton = ({ isDisabled }: PostButtonProps) => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      isDisabled={isDisabled || pending}
+      bg="blue.primary"
+      color="white"
+      borderRadius="full"
+      px={4}
+      _hover={{ bg: "blue.primaryHover" }}
+    >
+      Post
+    </Button>
+  );
+};

--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.tsx
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.tsx
@@ -2,7 +2,6 @@
 
 import React, { useRef } from "react";
 import {
-  Button,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -13,17 +12,18 @@ import {
   Box,
   IconButton,
   Avatar,
+  Text,
 } from "@chakra-ui/react";
 import { FaImage } from "react-icons/fa6";
 import { usePostModal } from "./use-post-modal";
 import { useSession } from "@/lib/components/session-context";
+import { PostButton } from "../post-button/post-button";
+import { useFormState } from "react-dom";
 
 interface PostModalProps {
   isIntercepted: boolean;
 }
 
-// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/500
-// Disable scrolling to the top of the page when the post modal opens.
 export const PostModal: React.FC<PostModalProps> = ({ isIntercepted }) => {
   const { user } = useSession();
   const {
@@ -33,6 +33,10 @@ export const PostModal: React.FC<PostModalProps> = ({ isIntercepted }) => {
     handlePostButtonClick,
     isPostButtonDisabled,
   } = usePostModal({ isIntercepted });
+
+  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/525
+  // - Replace useFormState with useActionState after upgrading React to v19.
+  const [message, formAction] = useFormState(handlePostButtonClick, undefined);
   const initialRef = useRef(null);
 
   return (
@@ -50,46 +54,51 @@ export const PostModal: React.FC<PostModalProps> = ({ isIntercepted }) => {
           top="8px"
           left="8px"
         />
-        <ModalBody py={4}>
-          <Flex mt={8}>
-            <Avatar size="md" name={user ? user?.name : ""} />
-            <Textarea
-              ref={initialRef}
-              value={postText}
-              onChange={handleTextAreaChange}
-              placeholder="What is happening?!"
-              border="none"
-              resize="none"
-              minH="100px"
-              _focus={{ boxShadow: "none" }}
-              fontSize="xl"
-            />
-          </Flex>
-          <Box borderTop="1px solid" borderColor="gray.600" mt={4} pt={4}>
-            <Flex justifyContent="space-between">
-              <IconButton
-                // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/407 - Enhance Post Functionality: Add Image Attachment Feature.
-
-                icon={<FaImage />}
-                aria-label="Add image"
-                variant="ghost"
-                color="blue.400"
-                borderRadius="full"
-                _hover={{ bg: "whiteAlpha.200" }}
-              />
-              <Button
-                onClick={handlePostButtonClick}
-                isDisabled={isPostButtonDisabled}
-                bg="blue.primary"
-                color="white"
-                borderRadius="full"
-                px={4}
-                _hover={{ bg: "blue.primaryHover" }}
+        <ModalBody pt="53px" pb={4}>
+          <form action={formAction}>
+            {message !== undefined && (
+              <Text
+                fontSize="14px"
+                lineHeight="16px"
+                px="16px"
+                py="12px"
+                bg="error.primary"
+                borderRadius="8px"
               >
-                Post
-              </Button>
+                {message}
+              </Text>
+            )}
+            <Flex mt={8}>
+              <Avatar size="md" name={user ? user?.name : ""} />
+              <Textarea
+                name="text"
+                ref={initialRef}
+                value={postText}
+                onChange={handleTextAreaChange}
+                placeholder="What is happening?!"
+                border="none"
+                resize="none"
+                minH="100px"
+                _focus={{ boxShadow: "none" }}
+                fontSize="xl"
+              />
             </Flex>
-          </Box>
+            <Box borderTop="1px solid" borderColor="gray.600" mt={4} pt={4}>
+              <Flex justifyContent="space-between">
+                <IconButton
+                  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/407
+                  // - Enhance Post Functionality: Add Image Attachment Feature.
+                  icon={<FaImage />}
+                  aria-label="Add image"
+                  variant="ghost"
+                  color="blue.400"
+                  borderRadius="full"
+                  _hover={{ bg: "whiteAlpha.200" }}
+                />
+                <PostButton isDisabled={isPostButtonDisabled} />
+              </Flex>
+            </Box>
+          </form>
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
@@ -10,7 +10,10 @@ interface usePostModalReturn {
   handleCloseButtonClick: () => void;
   postText: string;
   handleTextAreaChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  handlePostButtonClick: () => Promise<void>;
+  handlePostButtonClick: (
+    currentMessage: string | undefined,
+    formData: FormData
+  ) => Promise<string | undefined>;
   isPostButtonDisabled: boolean;
 }
 
@@ -30,19 +33,27 @@ export const usePostModal = ({
     setPostText(event.target.value);
   };
 
-  const handlePostButtonClick = async () => {
-    const res = await createPost({
-      user_id: `${process.env.NEXT_PUBLIC_USER_ID}`,
-      text: postText,
-    });
+  // currentMessage should be passed as the first argument due to the useFormState specification.
+  const handlePostButtonClick = async (
+    currentMessage: string | undefined,
+    formData: FormData
+  ) => {
+    const message =
+      "Something went wrong, but don't fret - let's give it another shot.";
+    try {
+      const res = await createPost({
+        user_id: `${process.env.NEXT_PUBLIC_USER_ID}`,
+        text: formData.get("text") as string,
+      });
 
-    if (res.ok) {
-      console.log(res.value);
+      if (!res.ok) {
+        return message;
+      }
+
       setPostText("");
-    } else {
-      // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/477
-      // - Display an error message to users if post creation fails.
-      console.log(res.error);
+      handleCloseButtonClick();
+    } catch (error) {
+      return message;
     }
   };
 

--- a/ts/twitter/src/lib/theme.ts
+++ b/ts/twitter/src/lib/theme.ts
@@ -14,6 +14,9 @@ const theme = {
       primary: "#1DA1F2",
       primaryHover: "#1A91DA",
     },
+    error: {
+      primary: "#3D0105",
+    },
   },
 };
 


### PR DESCRIPTION
## Issue Number
#477 

## Implementation Summary
This PR displays an error message to users if post creation fails. To handle the result of post creation, I used the `useFormState` hook. This hook takes an action function as its first argument and the initial form state as its second argument.  

By using `useFormState`, we can easily manage form submissions via Server Actions. When a user clicks the post button, the current form state and form data are automatically passed to the action function—in this case, `handlePostButtonClick`. The action function then returns the next form state based on the result of the Server Actions.  
For example, we can return an error message to indicate the Server Actions has failed.

## Scope of Impact
- This change affects the process of creating user posts.

## Particular points to check
Please check if you can see the following error message after clicking the "Post" button by following these steps:

1. Run `docker compose up`.
2. Open `localhost:3000/notifications` without running the backend to simulate a post creation failure.
3. Sign in, click the "Post" button on the sidebar, and try to create a post. You should see the error message.

![スクリーンショット 2024-12-01 10 48 04](https://github.com/user-attachments/assets/a5802c19-b429-4446-80f5-0ea1432a4e6b)

## Test
`ts/twitter/src/app/@modal/(.)compose/post/__test__/post-modal.spec.tsx` tests if the error message is in the component.

## Schedule
12/20

## References
- The error message from the original X
![スクリーンショット 2024-12-01 10 09 58](https://github.com/user-attachments/assets/474daa76-0e76-4579-a51a-adbc211c33bc)
