### PR TITLE
[Infra] Enabel access to the logging service

### DIFF
--- a/ts/docker-compose.yml
+++ b/ts/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - 3000:3000
     networks:
       - x_clone
+      - logging_network
     env_file:
       - .env.local
 
@@ -22,7 +23,10 @@ services:
       - "3002:3002"
     networks:
       - x_clone
+      - logging_network
 
 networks:
   x_clone:
+    external: true
+  logging_network:
     external: true


### PR DESCRIPTION
## Issue Number
#529 

## Implementation Summary
This pull request modifies the docker-compose setup, ensuring that the frontend service is now properly connected to the logging service’s network, allowing log data to be transmitted smoothly.

## Scope of Impact
Changes will take effect upon redeployment. With this update, the log routing will be adjusted so that logs previously retained in the frontend are now forwarded to the logging service.

## Particular points to check
Verify that the new network configuration doesn’t interfere with existing services or introduce unexpected dependencies. Ensure that the logging service still functions as intended for other parts of the system.

## Test
X-Clone
```
make up
```
Twitter-Clone(TS)
```
➜  ts git:(feature/#529_Enable_access_to_the_logging_service) ✗ d
ocker compose build
docker compose up -d
docker compose exec app bash
```

```
root@290a43ac81c5:/app/twitter# nc -vz rabbitmq 5672
Connection to rabbitmq (172.20.0.5) 5672 port [tcp/amqp] succeeded!
```
Log-service
```
make up
```

## Schedule
Target merge date: 12/21