### PR TITLE
[iOS] Implement Swipe and Pan Gesture to Enable Manual Side Menu Transition

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS/Root/AppRootViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/AppRootViewController.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import UIKit
 
+/// The root view controller of the app, responsible for managing the side menu and main content navigation.
 class AppRootViewController: UIViewController {
 
   // MARK: - Private Props
 
+  /// The controller responsible for the side menu transition animation.
   private let sideMenuTransitionController = SideMenuTransitionController()
 
+  /// The `UITabBarController` that manages the selected tab's view.
   private lazy var mainRootViewController: MainRootViewController = {
     let viewController = MainRootViewController.sharedInstance
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -15,14 +18,13 @@ class AppRootViewController: UIViewController {
     return viewController
   }()
 
+  /// The view controller responsible for displaying the side menu.
   private lazy var sideMenuViewController: UIHostingController = {
     let fakeUser = injectCurrentUser()
     let viewController = UIHostingController(
       rootView: SideMenuView(
         userName: fakeUser.userName, numOfFollowing: fakeUser.numOfFollowers,
         numOfFollowers: fakeUser.numOfFollowers, delegate: self))
-    viewController.modalPresentationStyle = .custom
-    viewController.transitioningDelegate = sideMenuTransitionController
     return viewController
   }()
 
@@ -31,6 +33,7 @@ class AppRootViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     setUpSubviews()
+    setUpSideMenuTransition()
   }
 
   // MARK: - Private API
@@ -47,16 +50,21 @@ class AppRootViewController: UIViewController {
     ])
   }
 
+  private func setUpSideMenuTransition() {
+    sideMenuTransitionController.setUpViewControllersForSideMenuTransition(
+      parentVC: self, mainVC: mainRootViewController, sideMenuVC: sideMenuViewController)
+  }
+
   // MARK: - Public API
 
   public func hideSideMenu() {
     // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/409
     // - Enable Smoother Transitions from SideMenu to Other Views.
-    sideMenuViewController.dismiss(animated: true)
+    sideMenuTransitionController.dismissSideMenu()
   }
 
   public func showSideMenu() {
-    present(sideMenuViewController, animated: true)
+    sideMenuTransitionController.presentSideMenu()
   }
 }
 
@@ -64,6 +72,7 @@ class AppRootViewController: UIViewController {
 
 extension AppRootViewController: SideMenuViewDelegate {
 
+  /// Pushes the user profile view controller into the navigation controller when the profile button is tapped in the side menu.
   func userProfileDidReceiveTap() {
     hideSideMenu()
     guard
@@ -74,6 +83,7 @@ extension AppRootViewController: SideMenuViewDelegate {
     selectedViewController.pushViewController(userProfileViewController, animated: true)
   }
 
+  /// Pushes the user bookmarks view controller into the navigation controller when the bookmarks button is tapped in the side menu.
   func bookmarksDidReceiveTap() {
     hideSideMenu()
     guard
@@ -84,6 +94,7 @@ extension AppRootViewController: SideMenuViewDelegate {
     selectedViewController.pushViewController(userBookmarksPageViewController, animated: true)
   }
 
+  /// Pushes the jobs view controller into the navigation controller when the jobs button is tapped in the side menu.
   func jobsDidReceiveTap() {
     hideSideMenu()
     guard
@@ -93,6 +104,7 @@ extension AppRootViewController: SideMenuViewDelegate {
     selectedViewController.pushViewController(JobsViewController(), animated: true)
   }
 
+  /// Pushes the user lists page view controller into the navigation controller when the lists button is tapped in the side menu.
   func listsDidReceiveTap() {
     hideSideMenu()
     guard
@@ -102,6 +114,7 @@ extension AppRootViewController: SideMenuViewDelegate {
     selectedViewController.pushViewController(UserListsPageViewController(), animated: true)
   }
 
+  /// Pushes the user follower requests page view controller into the navigation controller when the follower requests button is tapped in the side menu.
   func followerRequestsDidReceiveTap() {
     hideSideMenu()
     guard
@@ -113,6 +126,7 @@ extension AppRootViewController: SideMenuViewDelegate {
       userFollowerRequestsPageViewController, animated: true)
   }
 
+  /// Pushes the settings view controller into the navigation controller when the settings and privacy button is tapped in the side menu.
   func settingsAndPrivacyDidReceiveTap() {
     hideSideMenu()
     guard
@@ -123,6 +137,8 @@ extension AppRootViewController: SideMenuViewDelegate {
     selectedViewController.pushViewController(settingsViewController, animated: true)
   }
 
+  /// Pushes the user follow relations view controller into the navigation controller when the follow relations buttons are tapped in the side menu.
+  /// - Parameter userName: The username of the current user of the app.
   func userFollowRelationsButtonDidReceiveTap(userName: String) {
     hideSideMenu()
     guard
@@ -134,6 +150,7 @@ extension AppRootViewController: SideMenuViewDelegate {
   }
 }
 
+/// The view controller containing a user icon button that allows users to open the side menu by tapping the button.
 class ViewControllerWithUserIconButton: UIViewController {
 
   private var rootViewController: UIViewController {

--- a/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionAnimator.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionAnimator.swift
@@ -1,12 +1,19 @@
 import UIKit
 
+/// The animator that handles the presentation and dismissal transition animations of a side menu.
+/// During presentation, the side menu slides in from the left edge and moves to the right.
+/// During dismissal, the side menu slides out to the left.
 class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 
   // MARK: - Public Props
 
+  /// The indicator whether the animator is presenting or dismissing the side menu.
   public var isPresenting: Bool = true
 
+  /// The action that is called when the dimming view is tapped.
   public var dimmingViewTapAction: (() -> Void)? = nil
+  /// The action that is called when the container view is panned with a gesture.
+  public var containerViewPanAction: ((_ panGesture: UIPanGestureRecognizer) -> Void)? = nil
 
   // MARK: - Private Props
 
@@ -16,11 +23,15 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
     static let duration: TimeInterval = 0.25
   }
 
+  /// The view that dims the background when the side menu is presented.
   private let dimmingView: UIView = {
     let view = UIView()
     view.backgroundColor = .black
     return view
   }()
+
+  /// The gesture recognizer that handles pan gestures on the container view to initiate and manage the side menu transition.
+  private let panGesture = UIPanGestureRecognizer()
 
   // MARK: - UIViewControllerAnimatedTransitioning
 
@@ -40,6 +51,8 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
   // MARK: - Transition Animations
 
+  /// Implements the side menu's presentation animation, sliding it in from the left with a background dimming effect.
+  /// - Parameter transitionContext: The context of the transition, containing the to/from views and other transition-related properties.
   private func presentSideMenuTransitionAnimation(
     using transitionContext: any UIViewControllerContextTransitioning
   ) {
@@ -77,6 +90,9 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
     toView.frame.origin.x = -LayoutConstant.sideMenuWidth
 
+    panGesture.addTarget(self, action: #selector(onPanAction))
+    containerView.addGestureRecognizer(panGesture)
+
     UIView.animate(
       withDuration: LayoutConstant.duration,
       animations: { [weak self] in
@@ -90,6 +106,8 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
       })
   }
 
+  /// Implements the side menu's dismissal animation, sliding it out to the left and fading out the background dimming view.
+  /// - Parameter transitionContext: The context of the transition, containing the to/from views and other transition-related properties.
   private func dismissalSideMenuTransitionAnimation(
     using transitionContext: any UIViewControllerContextTransitioning
   ) {
@@ -113,10 +131,17 @@ class SideMenuTransitionAnimator: NSObject, UIViewControllerAnimatedTransitionin
       })
   }
 
-  // MARK: - Tap Gesture Handling
+  // MARK: - Gesture Handling
 
+  /// Handles tap gestures on the dimming view to trigger the dimming view tap action defined in `SideMenuTransitionController`.
   @objc
   private func onTapAction() {
     dimmingViewTapAction?()
+  }
+
+  /// Handles pan gestures on the container view to trigger the side menu pan action defined in `SideMenuTransitionController`.
+  @objc
+  private func onPanAction() {
+    containerViewPanAction?(panGesture)
   }
 }

--- a/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/SideMenu/SideMenuTransitionController.swift
@@ -1,24 +1,196 @@
+import SwiftUI
 import UIKit
 
-// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/510
-// - Implement Swipe and Pan Gesture to Enable Manual Side Menu Transition.
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/531
+// - Enable Side Menu Access via Gesture Interaction Within ScrollView.
 
-class SideMenuTransitionController: NSObject, UIViewControllerTransitioningDelegate {
+/// The controller that manages the custom transition animations for presenting and dismissing a side menu.
+/// It also handles interactive gesture-based transitions using `UIPercentDrivenInteractiveTransition`.
+class SideMenuTransitionController: NSObject {
 
+  // MARK: - Private Props
+
+  /// The animator responsible for implementing the side menu transition animation.
   private let animator = SideMenuTransitionAnimator()
 
+  /// The percent-driven interactive transition object for managing pan-gesture-based transition animations.
+  private var interactiveTransition: UIPercentDrivenInteractiveTransition? = nil
+
+  /// The parent view controller of the main and side menu view controller, responsible for presenting and dismissing the side menu.
+  private var parentViewController: UIViewController? = nil
+  /// The view controller where the pan gesture is recognized to trigger the presenting side menu transition.
+  private var mainViewController: UIViewController? = nil
+  /// The view controller of the side menu view.
+  private var sideMenuViewController: UIViewController? = nil
+
+  // MARK: - Public API
+
+  /// Sets up the view controllers involved in the side menu transition, configuring the presentation style and adding a pan gesture recognizer.
+  ///
+  /// - Parameters:
+  ///   - parentVC: The parent view controller of the main and side menu view controller, responsible for presenting and dismissing the side menu.
+  ///   - mainVC: The view controller where the pan gesture is recognized to trigger the presenting side menu transition.
+  ///   - sideMenuVC: The view controller of the side menu view.
+  public func setUpViewControllersForSideMenuTransition(
+    parentVC: UIViewController, mainVC: UIViewController, sideMenuVC: UIViewController
+  ) {
+    self.parentViewController = parentVC
+    self.mainViewController = mainVC
+    self.sideMenuViewController = sideMenuVC
+
+    guard let sideMenuViewController = sideMenuViewController else { return }
+    sideMenuViewController.modalPresentationStyle = .custom
+    sideMenuViewController.transitioningDelegate = self
+
+    let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+    mainVC.view.addGestureRecognizer(panGesture)
+  }
+
+  public func presentSideMenu() {
+    guard let parentViewController = parentViewController,
+      let sideMenuViewController = sideMenuViewController
+    else {
+      return
+    }
+    parentViewController.present(sideMenuViewController, animated: true)
+  }
+
+  public func dismissSideMenu() {
+    guard let sideMenuViewController = sideMenuViewController else { return }
+    sideMenuViewController.dismiss(animated: true)
+  }
+
+  // MARK: - Gesture Handling
+
+  /// Handles a pan gesture to manage the interactive side menu animation transition,
+  /// updating, finishing, or canceling based on the gesture's horizontal translation or velocity.
+  ///
+  /// - Parameter gesture: The pan gesture recognizer managing the side menu animation transition.
+  @objc
+  private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    switch gesture.state {
+    case .began:
+      interactiveTransition = UIPercentDrivenInteractiveTransition()
+      interactiveTransition?.completionCurve = .linear
+      presentSideMenu()
+    case .changed:
+      guard let gestureView = gesture.view else { return }
+      let horizontalTranslation = gesture.translation(in: gestureView).x
+      let percentComplete = max(horizontalTranslation / gestureView.bounds.width, 0)
+      interactiveTransition?.update(percentComplete)
+    case .ended:
+      if let gestureView = gesture.view, gesture.velocity(in: gestureView).x > 0 {
+        interactiveTransition?.finish()
+      } else {
+        interactiveTransition?.cancel()
+      }
+      interactiveTransition = nil
+    case .cancelled:
+      cancelInteractiveTransition()
+    case .failed:
+      cancelInteractiveTransition()
+    default:
+      break
+    }
+  }
+}
+
+extension SideMenuTransitionController: UIViewControllerTransitioningDelegate {
+
+  // MARK: Delegate Methods
+
+  /// Provides the animator responsible for managing the presentation of the side menu,
+  /// and defines actions for user interactions on the dimming view and the container view.
+  ///
+  /// - Parameters:
+  ///   - presented: The side menu view controller that is about to be presented onscreen.
+  ///   - presenting: The view controller presenting the side menu.
+  ///   - source: The view controller that initiated the presentation transition by calling `present(_:animated:completion:)`.
+  /// - Returns: An animator configured with actions triggered by a tap gesture on the dimming view and a pan gesture on the container view.
   func animationController(
     forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController
   ) -> (any UIViewControllerAnimatedTransitioning)? {
     animator.dimmingViewTapAction = { [weak presented] in presented?.dismiss(animated: true) }
+    animator.containerViewPanAction = { [weak self, weak presented] gesture in
+      switch gesture.state {
+      case .began:
+        self?.setUpInteractiveTransitionForDismissal(forPresented: presented)
+      case .changed:
+        guard let gestureView = gesture.view else { return }
+        let horizontalTranslation = gesture.translation(in: gestureView).x
+        let percentComplete = -min(horizontalTranslation / gestureView.bounds.width, 0)
+        self?.interactiveTransition?.update(percentComplete)
+      case .ended:
+        self?.completeInteractiveTransitionForDismissal(withGesture: gesture)
+      case .cancelled:
+        self?.cancelInteractiveTransition()
+      case .failed:
+        self?.cancelInteractiveTransition()
+      default:
+        break
+      }
+    }
+
     animator.isPresenting = true
     return animator
   }
 
+  /// Provides the animator responsible for managing the dismissal transition of the side menu.
+  ///
+  /// - Parameter dismissed: The side menu view controller that is about to be dismissed.
+  /// - Returns: The animator responsible for the dismissal transition.
   func animationController(forDismissed dismissed: UIViewController) -> (
     any UIViewControllerAnimatedTransitioning
   )? {
     animator.isPresenting = false
     return animator
+  }
+
+  func interactionControllerForPresentation(
+    using animator: any UIViewControllerAnimatedTransitioning
+  ) -> (any UIViewControllerInteractiveTransitioning)? {
+    if animator is SideMenuTransitionAnimator {
+      return interactiveTransition
+    } else {
+      return nil
+    }
+  }
+
+  func interactionControllerForDismissal(using animator: any UIViewControllerAnimatedTransitioning)
+    -> (any UIViewControllerInteractiveTransitioning)?
+  {
+    if animator is SideMenuTransitionAnimator {
+      return interactiveTransition
+    } else {
+      return nil
+    }
+  }
+
+  // MARK: - Private API
+
+  private func setUpInteractiveTransitionForDismissal(forPresented presented: UIViewController?) {
+    interactiveTransition = UIPercentDrivenInteractiveTransition()
+    interactiveTransition?.completionCurve = .linear
+    presented?.dismiss(animated: true)
+  }
+
+  /// Determines whether the interactive transition should be completed or canceled
+  /// based on the horizontal velocity of the gesture.
+  ///
+  /// - Parameter gesture: The pan gesture recognizer used to control the transition.
+  private func completeInteractiveTransitionForDismissal(
+    withGesture gesture: UIPanGestureRecognizer
+  ) {
+    if let gestureView = gesture.view, gesture.velocity(in: gestureView).x < 0 {
+      interactiveTransition?.finish()
+    } else {
+      interactiveTransition?.cancel()
+    }
+    interactiveTransition = nil
+  }
+
+  private func cancelInteractiveTransition() {
+    interactiveTransition?.cancel()
+    interactiveTransition = nil
   }
 }


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/510

## Implementation Summary
This PR introduces a manual side menu transition controlled via a pan gesture.

## Scope of Impact
Users can now open and close the side menu by dragging it with a pan gesture.

## Particular points to check
Please review if the way of introducing the `UIPercentDrivenInteractiveTransition` is appropriate.

## Reference
https://github.com/user-attachments/assets/8018fa33-888e-473a-9b65-5aa0dbee1d29

## Schedule
Until 12/21.

## Note
- In `ScrollView`, users still can't open the side menu by gesture. This issue will be addressed in the https://github.com/okuda-seminar/Twitter-Clone/issues/531. 
- Although the issue and PR title mention a swipe gesture, the implementation uses only a pan gesture because it meets the required functionality without a swipe gesture for now.