### PR TITLE
[iOS] Enable Side Menu Access via Gesture Interaction within ScrollView

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS/Root/MainRootViewController.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Root/MainRootViewController.swift
@@ -1,9 +1,11 @@
 import UIKit
 
+/// The controller managing multiple view controllers in a tab bar, each identified by a unique tag.
 class MainRootViewController: UITabBarController {
 
   // MARK: - Public Props
 
+  /// The shared instance of `MainRootViewController`, providing global access to it.
   public static var sharedInstance = MainRootViewController()
 
   // MARK: - Private Props
@@ -31,6 +33,7 @@ class MainRootViewController: UITabBarController {
     tabBar.backgroundColor = .systemBackground
   }
 
+  /// Sets up the notification center and initializes the tab bar items with their corresponding view controllers.
   private func setUpSubviews() {
     let notificationCenter = NotificationCenter.default
 
@@ -83,11 +86,13 @@ class MainRootViewController: UITabBarController {
 
   // MARK: - NSNotification
 
+  /// Handles the tap gesture on the home tab bar item to trigger the corresponding action defined in `HomeViewController`.
   @objc
   private func didTapHomeTabBarItem() {
     selectedIndex = TabBarItemTag.home.rawValue
   }
 
+  /// Handles the long press gesture on the home tab bar item to trigger the corresponding action defined in `HomeViewController`.
   @objc
   private func didLongPressHomeTabBarItem() {
     selectedIndex = TabBarItemTag.home.rawValue


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/531

## Implementation Summary
This PR implements the side menu access via the pan gesture within a scroll view.

## Scope of Impact
When users pan the view to the right within a scroll view, they can open the side menu. Additionally, when there is a horizontal scroll view, and users can still scroll the view to the right, they can scroll it rather than open the side menu. 

## Reference
https://github.com/user-attachments/assets/16644024-6a90-416f-989a-b3bcf083c3ff

## Schedule
Until 12/28.

## Note
Besides the side menu access implementation, I added documentation comments to `MainRootViewController`.