### PR TITLE
[TS] Add event type handling for SSE timeline streaming

### DIFF
--- a/ts/twitter/src/app/home/_components/timeline/__mocks__/post-data.ts
+++ b/ts/twitter/src/app/home/_components/timeline/__mocks__/post-data.ts
@@ -1,10 +1,26 @@
-import { FollowingPostsResponse } from "@/lib/actions/fetch-following-posts";
+import { TimelineEventResponse, TimelineEventType } from "../use-timeline-feed";
 
-export const mockPosts: FollowingPostsResponse = [
+export const mockPosts: TimelineEventResponse[] = [
   {
-    id: "post-123",
-    user_id: "user-789",
-    text: "test text",
-    created_at: "2024-01-01",
+    event_type: TimelineEventType.TimelineAccessed,
+    posts: [
+      {
+        id: "post-123",
+        user_id: "user-789",
+        text: "test text",
+        created_at: "2024-01-01",
+      },
+    ],
+  },
+  {
+    event_type: TimelineEventType.PostCreated,
+    posts: [
+      {
+        id: "post-123",
+        user_id: "user-789",
+        text: "created post",
+        created_at: "2024-01-02",
+      },
+    ],
   },
 ];

--- a/ts/twitter/src/app/home/_components/timeline/__test__/timeline-feed.spec.tsx
+++ b/ts/twitter/src/app/home/_components/timeline/__test__/timeline-feed.spec.tsx
@@ -19,16 +19,28 @@ describe("Timeline Feed Tests", () => {
     jest.clearAllMocks();
   });
 
-  test("Displays posts in timeline when SSE message is received", () => {
+  test("Displays initial posts in timeline when TimelineAccessed event is received", () => {
     render(<TimelineFeed />);
 
     act(() => {
       const messageHandler = mockEventSource.onmessage;
-      messageHandler({ data: JSON.stringify(mockPosts) });
+      messageHandler({ data: JSON.stringify(mockPosts[0]) });
     });
 
-    expect(screen.getByText(mockPosts[0].user_id)).toBeInTheDocument();
-    expect(screen.getByText(mockPosts[0].text)).toBeInTheDocument();
+    expect(screen.getByText(mockPosts[0].posts[0].user_id)).toBeInTheDocument();
+    expect(screen.getByText(mockPosts[0].posts[0].text)).toBeInTheDocument();
+  });
+
+  test("Adds new post to timeline when PostCreated event is received", () => {
+    render(<TimelineFeed />);
+
+    act(() => {
+      const messageHandler = mockEventSource.onmessage;
+      messageHandler({ data: JSON.stringify(mockPosts[1]) });
+    });
+
+    expect(screen.getByText(mockPosts[1].posts[0].user_id)).toBeInTheDocument();
+    expect(screen.getByText(mockPosts[1].posts[0].text)).toBeInTheDocument();
   });
 
   test("Displays 'post not found.' when there are no posts", () => {

--- a/ts/twitter/src/app/home/_components/timeline/use-timeline-feed.ts
+++ b/ts/twitter/src/app/home/_components/timeline/use-timeline-feed.ts
@@ -1,15 +1,40 @@
 import { useRef, useState, useEffect } from "react";
 import { FollowingPostsResponse } from "@/lib/actions/fetch-following-posts";
 import { ERROR_MESSAGES } from "@/lib/constants/error-messages";
+import { Post } from "@/lib/models/post";
 
 interface useTimelineFeedReturn {
   errorMessage: string | null;
   posts: FollowingPostsResponse;
 }
 
+export type TimelineEventResponse =
+  | TimelineAccessedResponse
+  | PostCreatedResponse
+  | PostDeletedResponse;
+
+export enum TimelineEventType {
+  TimelineAccessed = "TimelineAccessed",
+  PostCreated = "PostCreated",
+  PostDeleted = "PostDeleted",
+}
+
+interface TimelineAccessedResponse {
+  event_type: TimelineEventType.TimelineAccessed;
+  posts: Post[];
+}
+
+interface PostCreatedResponse {
+  event_type: TimelineEventType.PostCreated;
+  posts: Post[];
+}
+
+interface PostDeletedResponse {
+  event_type: TimelineEventType.PostDeleted;
+  posts: Post[];
+}
+
 export const useTimelineFeed = (): useTimelineFeedReturn => {
-  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/516
-  // - Add event type handling for SSE timeline streaming.
   const [posts, setPosts] = useState<FollowingPostsResponse>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -24,11 +49,20 @@ export const useTimelineFeed = (): useTimelineFeedReturn => {
 
     eventSource.onmessage = (event) => {
       try {
-        const newPosts: FollowingPostsResponse = JSON.parse(event.data);
-        if (newPosts.length === 0) {
-          return;
+        const newPosts: TimelineEventResponse = JSON.parse(event.data);
+        switch (newPosts.event_type) {
+          case TimelineEventType.TimelineAccessed:
+          case TimelineEventType.PostCreated:
+            if (!newPosts.posts || newPosts.posts.length === 0) {
+              return;
+            }
+            setPosts((prevPosts) => [...newPosts.posts, ...prevPosts]);
+            break;
+          case TimelineEventType.PostDeleted:
+            // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/540
+            // - Implement timeline post deletion with SSE event handling.
+            return;
         }
-        setPosts((prevPosts) => [...newPosts, ...prevPosts]);
       } catch (err) {
         setErrorMessage(ERROR_MESSAGES.INVALID_DATA);
       }


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/516

## Implementation Summary
Added event types for EventSource messages to handle different SSE events. The system now processes post information updates based on the specific event type received.

## Particular points to check
Please verify that the timeline is displayed in the following tab. Currently, since the `follow` functionality has not been implemented yet, only your own posts will be displayed.

#Reference

https://github.com/user-attachments/assets/912ae43f-4d2a-468f-84bd-20d84c58e34a



## Test
`src/app/home/timeline/__test__/timeline-feed.spec.tsx`
1. Start the frontend server (in the Twitter-Clone directory)
```
$ docker compose up -d
```
2. Enter the application container and run all test files
```
$ docker compose exec app bash
$ yarn test
```
## Review Considerations
Please review using the latest version of x-clone-backend.

## Schedule
2025/1/19
