### PR TITLE
[iOS] Fix Typos in UIColor+Core.swift Color Names

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS/Features/Banner/BannerView.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Banner/BannerView.swift
@@ -37,11 +37,11 @@ struct BannerView: View {
         DismissalButton()
       }
     }
-    .background(Color(uiColor: .branededLightBlue2))
+    .background(Color(uiColor: .brandedLightBlue2))
     .clipShape(RoundedRectangle(cornerRadius: LayoutConstant.edgeCornerRadius))
     .overlay(
       RoundedRectangle(cornerRadius: LayoutConstant.edgeCornerRadius)
-        .stroke(Color(uiColor: .branededLightBlue))
+        .stroke(Color(uiColor: .brandedLightBlue))
     )
     .padding()
   }

--- a/swift/Twitter-iOS/Twitter-iOS/SDK/UI/Color/UIColor+Core.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/SDK/UI/Color/UIColor+Core.swift
@@ -20,8 +20,8 @@ extension UIColor {
   // MARK: - General
 
   static let brandedBlue = createCustomUIColor(red: 28, green: 134, blue: 237)
-  static let branededLightBlue = createCustomUIColor(red: 124, green: 184, blue: 225)
-  static let branededLightBlue2 = createCustomUIColor(red: 227, green: 242, blue: 252)
+  static let brandedLightBlue = createCustomUIColor(red: 124, green: 184, blue: 225)
+  static let brandedLightBlue2 = createCustomUIColor(red: 227, green: 242, blue: 252)
 
   // MARK: - Text
 


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/546

## Implementation Summary
This PR modifies typos in `UIColor+Core`.swift

- Previous: `branededLightBlue`, `branededLightBlue2`
- Corrected: `brandedLightBlue`, `brandedLightBlue2`

## Schedule
Until 2/8.
