### PR TITLE
[TS] Implement a log-sending function for each event type

### DIFF
--- a/ts/twitter/src/lib/sdk/rabbitmq-logger-sdk/_test_/rabbitmq-logger.test.ts
+++ b/ts/twitter/src/lib/sdk/rabbitmq-logger-sdk/_test_/rabbitmq-logger.test.ts
@@ -22,7 +22,7 @@ describe("RabbitMqLogger", () => {
     getMock = jest.fn().mockResolvedValue({
       content: Buffer.from(
         JSON.stringify({
-          eventType: "click",
+          eventType: "interaction",
           objectId: "12345",
           createdAt: new Date(),
         }),
@@ -51,17 +51,31 @@ describe("RabbitMqLogger", () => {
     jest.clearAllMocks();
   });
 
-  it("should send a structured JSON log with auto-generated created_at to logs queue", async () => {
+  it("should send a interaction log to the logs queue", async () => {
     const objectId = "98765";
-    const eventName = "click";
 
-    await expect(logger.sendLog(eventName, objectId)).resolves.not.toThrow();
-    expect(sendToQueueMock).toHaveBeenCalled();
+    await expect(logger.sendInteractionLog(objectId)).resolves.not.toThrow();
+    expect(sendToQueueMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Buffer),
+      { persistent: true },
+    );
   });
 
-  it("should send multiple logs independently to logs queue", async () => {
-    await expect(logger.sendLog("click", "12345")).resolves.not.toThrow();
-    await expect(logger.sendLog("impression", "23456")).resolves.not.toThrow();
+  it("should send an impression log to the logs queue", async () => {
+    const objectId = "54321";
+
+    await expect(logger.sendImpressionLog(objectId)).resolves.not.toThrow();
+    expect(sendToQueueMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Buffer),
+      { persistent: true },
+    );
+  });
+
+  it("should send multiple logs independently", async () => {
+    await expect(logger.sendInteractionLog("12345")).resolves.not.toThrow();
+    await expect(logger.sendImpressionLog("23456")).resolves.not.toThrow();
 
     expect(sendToQueueMock).toHaveBeenCalledTimes(2);
   });
@@ -86,7 +100,7 @@ describe("RabbitMqLogger", () => {
     );
 
     const errorLogger = new RabbitMqLogger();
-    await expect(errorLogger.sendLog("click", "12345")).rejects.toThrow(
+    await expect(errorLogger.sendInteractionLog("12345")).rejects.toThrow(
       "Connection failed",
     );
   });

--- a/ts/twitter/src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts
+++ b/ts/twitter/src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts
@@ -2,7 +2,16 @@ import amqp from "amqplib";
 
 export class RabbitMqLogger {
   private static readonly QUEUE_NAME = "logs";
-  async sendLog(eventName: string, objectId: string): Promise<void> {
+
+  async sendInteractionLog(objectId: string): Promise<void> {
+    await this.sendLog("interaction", objectId);
+  }
+
+  async sendImpressionLog(objectId: string): Promise<void> {
+    await this.sendLog("impression", objectId);
+  }
+
+  private async sendLog(eventName: string, objectId: string): Promise<void> {
     let connection: amqp.Connection | undefined = undefined;
     let channel: amqp.Channel | undefined = undefined;
 
@@ -30,6 +39,7 @@ export class RabbitMqLogger {
         Buffer.from(JSON.stringify(logMessage)),
         { persistent: true },
       );
+
       console.log(`Log sent: ${JSON.stringify(logMessage)}`);
     } catch (error) {
       console.error("Failed to send log:", error);


### PR DESCRIPTION
## Issue Number
#579 

## Implementation Summary
Refactored RabbitMqLogger to include separate methods for sending tap logs and impression logs to improve modularity.

## Particular points to check
Refactor the sdk.


## Test
```
 twitter git:(feature/#579_Refactor_the_ctr_log_sdk) ✗ yarn test
yarn run v1.22.22
$ jest
 PASS  src/lib/actions/__test__/fetch-following-posts.test.ts
 PASS  src/lib/sdk/rabbitmq-logger-sdk/_test_/rabbitmq-logger.test.ts
  ● Console

    console.log
      Log sent: {"eventType":"tap","objectId":"98765","createdAt":"2025-02-25T02:57:20.303Z"}

      at RabbitMqLogger.log [as sendLogMessage] (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:46:15)

    console.log
      Log sent: {"eventType":"impression","objectId":"54321","createdAt":"2025-02-25T02:57:20.319Z"}

      at RabbitMqLogger.log [as sendLogMessage] (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:46:15)

    console.log
      Log sent: {"eventType":"tap","objectId":"12345","createdAt":"2025-02-25T02:57:20.323Z"}

      at RabbitMqLogger.log [as sendLogMessage] (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:46:15)

    console.log
      Log sent: {"eventType":"impression","objectId":"23456","createdAt":"2025-02-25T02:57:20.324Z"}

      at RabbitMqLogger.log [as sendLogMessage] (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:46:15)

    console.error
      Failed to send log: Error: Connection failed
          at Object.<anonymous> (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/src/lib/sdk/rabbitmq-logger-sdk/_test_/rabbitmq-logger.test.ts:99:7)
          at Promise.then.completed (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/utils.js:298:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/utils.js:231:10)
          at _callCircusTest (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/run.js:316:40)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at _runTest (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/run.js:252:3)
          at _runTestsForDescribeBlock (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/run.js:126:9)
          at _runTestsForDescribeBlock (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/run.js:121:9)
          at run (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/run.js:71:3)
          at runAndTransformResultsToJestFormat (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
          at jestAdapter (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
          at runTestInternal (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-runner/build/runTest.js:367:16)
          at runTest (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-runner/build/runTest.js:444:34)
          at Object.worker (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/jest-runner/build/testWorker.js:106:12)

      46 |       console.log(`Log sent: ${JSON.stringify(logMessage)}`);
      47 |     } catch (error) {
    > 48 |       console.error("Failed to send log:", error);
         |               ^
      49 |       throw error;
      50 |     } finally {
      51 |       if (channel) await channel.close();

      at RabbitMqLogger.error [as sendLogMessage] (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:48:15)
      at RabbitMqLogger.sendTapLog (src/lib/sdk/rabbitmq-logger-sdk/rabbitmq-logger.ts:7:5)
      at Object.<anonymous> (src/lib/sdk/rabbitmq-logger-sdk/_test_/rabbitmq-logger.test.ts:103:5)

 PASS  src/lib/actions/__test__/create-post.test.ts
 PASS  src/lib/actions/__test__/find-user-by-id.test.ts
 PASS  src/app/home/__test__/home.spec.tsx
 PASS  src/app/home/_components/timeline/__test__/timeline-feed.spec.tsx
 PASS  src/app/notifications/__test__/notifications.spec.tsx
 PASS  src/app/posts/[id]/__test__/post-detail.spec.tsx
 PASS  src/app/@modal/(.)compose/post/__test__/post-modal.spec.tsx
  ● Console

    console.error
      Warning: Invalid value for prop `action` on <form> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://reactjs.org/link/attribute-behavior 
          at form
          at div
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@emotion/react/dist/emotion-element-f93e57b0.cjs.dev.js:62:23
          at ChakraComponent (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/system/src/system.ts:88:53)
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/modal/src/modal-body.tsx:17:11
          at section
          at MotionComponent (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/framer-motion/dist/cjs/index.js:499:22)
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@emotion/react/dist/emotion-element-f93e57b0.cjs.dev.js:62:23
          at ChakraComponent (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/system/src/system.ts:88:53)
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/modal/src/modal-transition.tsx:51:13
          at div
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@emotion/react/dist/emotion-element-f93e57b0.cjs.dev.js:62:23
          at ChakraComponent (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/system/src/system.ts:88:53)
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/react-remove-scroll/dist/es5/UI.js:16:21
          at div
          at FocusLockUI (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/react-focus-lock/dist/cjs/Lock.js:26:31)
          at FocusLockUICombination
          at FocusLock (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/focus-lock/src/focus-lock.tsx:67:5)
          at ModalFocusScope (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/modal/src/modal-focus.tsx:29:7)
          at /Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/modal/src/modal-content.tsx:32:7
          at DefaultPortal (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/portal/src/portal.tsx:40:11)
          at Portal
          at PresenceChild (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/framer-motion/dist/cjs/index.js:10879:26)
          at AnimatePresence (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/framer-motion/dist/cjs/index.js:10981:28)
          at Modal (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/node_modules/@chakra-ui/modal/src/modal.tsx:175:18)
          at isIntercepted (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.tsx:28:55)
          at children (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/src/lib/components/session-context.tsx:20:3)

      21 | describe("Post Modal Tests", () => {
      22 |   test("Rendering intercepted Post Modal should succeed", () => {
    > 23 |     render(<PostModal isIntercepted={true} />, { wrapper: SessionProvider });
         |           ^
      24 |   });
      25 |
      26 |   test("Rendering non-intercepted Post Modal should succeed", () => {

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at warnUnknownProperties (node_modules/react-dom/cjs/react-dom.development.js:3815:7)
      at validateProperties$2 (node_modules/react-dom/cjs/react-dom.development.js:3827:3)
      at validatePropertiesInDevelopment (node_modules/react-dom/cjs/react-dom.development.js:9541:5)
      at setInitialProperties (node_modules/react-dom/cjs/react-dom.development.js:9830:5)
      at finalizeInitialChildren (node_modules/react-dom/cjs/react-dom.development.js:10950:3)
      at completeWork (node_modules/react-dom/cjs/react-dom.development.js:22232:17)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:26632:16)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:26607:5)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:26505:5)
      at renderRootSync (node_modules/react-dom/cjs/react-dom.development.js:26473:7)
      at performSyncWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:26124:20)
      at flushSyncCallbacks (node_modules/react-dom/cjs/react-dom.development.js:12042:22)
      at commitRootImpl (node_modules/react-dom/cjs/react-dom.development.js:26998:3)
      at commitRoot (node_modules/react-dom/cjs/react-dom.development.js:26721:5)
      at finishConcurrentRender (node_modules/react-dom/cjs/react-dom.development.js:26020:9)
      at performConcurrentWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:25848:7)
      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
      at act (node_modules/react/cjs/react.development.js:2582:11)
      at node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (node_modules/@testing-library/react/dist/pure.js:180:26)
      at render (node_modules/@testing-library/react/dist/pure.js:271:10)
      at Object.<anonymous> (/Users/ryoma/Desktop/okudaseminar/Project/Twitter-Clone/ts/twitter/src/app/@modal/(.)compose/post/__test__/post-modal.spec.tsx:23:11)


Test Suites: 9 passed, 9 total
Tests:       28 passed, 28 total
Snapshots:   0 total
Time:        2.007 s, estimated 3 s
Ran all test suites.
✨  Done in 3.13s.

```

## Schedule
3/1

