### PR TITLE
[TS] Centralize Error Messages Management

### DIFF
--- a/ts/twitter/src/app/home/_components/timeline/timeline-feed-service.ts
+++ b/ts/twitter/src/app/home/_components/timeline/timeline-feed-service.ts
@@ -44,7 +44,7 @@ export interface TimelineFeedService {
  * - disconnect(): Closes the SSE connection and cleans up resources.
  *   Should be called when the timeline feed is no longer needed.
  */
-export class SseTimelineFeedServicel implements TimelineFeedService {
+export class SseTimelineFeedService implements TimelineFeedService {
   private eventSource: EventSource | null = null;
 
   connect(
@@ -87,5 +87,5 @@ export const createTimelineFeedService = (): TimelineFeedService => {
     }
     return testInstance;
   }
-  return new SseTimelineFeedServicel();
+  return new SseTimelineFeedService();
 };

--- a/ts/twitter/src/lib/actions/__test__/create-post.test.ts
+++ b/ts/twitter/src/lib/actions/__test__/create-post.test.ts
@@ -1,3 +1,4 @@
+import { STATUS_TEXT } from "@/lib/constants/error-messages";
 import { createPost } from "../create-post";
 
 describe("createPost Tests", () => {
@@ -50,9 +51,7 @@ describe("createPost Tests", () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
-        // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/489
-        // - Centralize Error Messages Management.
-        statusText: "Internal Server Error",
+        statusText: STATUS_TEXT.INTERNAL_SERVER_ERROR,
       });
 
       // Act
@@ -66,7 +65,7 @@ describe("createPost Tests", () => {
         ok: false,
         error: {
           status: 500,
-          statusText: "Internal Server Error",
+          statusText: STATUS_TEXT.INTERNAL_SERVER_ERROR,
         },
       });
     });

--- a/ts/twitter/src/lib/actions/__test__/find-user-by-id.test.ts
+++ b/ts/twitter/src/lib/actions/__test__/find-user-by-id.test.ts
@@ -1,3 +1,4 @@
+import { STATUS_TEXT } from "@/lib/constants/error-messages";
 import { findUserById } from "../find-user-by-id";
 
 describe("findUserById Tests", () => {
@@ -51,7 +52,7 @@ describe("findUserById Tests", () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
-        statusText: "Internal Server Error",
+        statusText: STATUS_TEXT.INTERNAL_SERVER_ERROR,
       });
 
       // Act
@@ -62,7 +63,7 @@ describe("findUserById Tests", () => {
         ok: false,
         error: {
           status: 500,
-          statusText: "Internal Server Error",
+          statusText: STATUS_TEXT.INTERNAL_SERVER_ERROR,
         },
       });
     });

--- a/ts/twitter/src/lib/constants/error-messages.ts
+++ b/ts/twitter/src/lib/constants/error-messages.ts
@@ -3,3 +3,7 @@ export const ERROR_MESSAGES = {
   INVALID_DATA: "Invalid data received.",
   CONNECTION_ERROR: "Connection error occurred.",
 } as const;
+
+export const STATUS_TEXT = {
+  INTERNAL_SERVER_ERROR: "Internal Server Error",
+} as const;


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/489

## Implementation Summary
The error messages were hard coded in the tests, so I moved them into ERROR_MESSAGE.


## Particular points to check
Please make sure the tests pass.

## Test
`ts/twitter/src/lib/actions/__test__/create-post.test.ts`
`ts/twitter/src/lib/actions/__test__/find-user-by-id.test.ts`

## Schedule
2/28
