### PR TITLE
[TS] Implement login screen modals

### DIFF
--- a/ts/twitter/src/app/login/_components/account-modal.tsx
+++ b/ts/twitter/src/app/login/_components/account-modal.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Button } from "@chakra-ui/react";
+import type React from "react";
+
+interface AccountModalProps {
+  onNext: () => void;
+}
+
+export const AccountModal: React.FC<AccountModalProps> = ({ onNext }) => {
+  return (
+    <Button
+      onClick={onNext}
+      fontSize="lg"
+      borderRadius="full"
+      bg="white"
+      color="black"
+      fontWeight="bold"
+    >
+      Next
+    </Button>
+  );
+};

--- a/ts/twitter/src/app/login/_components/login-modal.tsx
+++ b/ts/twitter/src/app/login/_components/login-modal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Box, Flex } from "@chakra-ui/react";
+import { useState } from "react";
+import type React from "react";
+import { AccountModal } from "./account-modal";
+import { PasswordModal } from "./password-modal";
+
+export const LoginModal: React.FC = () => {
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+
+  const handleNextButtonClick = () => {
+    setShowPasswordModal(true);
+  };
+
+  return (
+    <Flex align="center" justify="center" minH="100vh">
+      <Box
+        width="600px"
+        height="650px"
+        bg="black"
+        borderRadius="md"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+      >
+        {!showPasswordModal ? (
+          <AccountModal onNext={handleNextButtonClick} />
+        ) : (
+          <PasswordModal />
+        )}
+      </Box>
+    </Flex>
+  );
+};

--- a/ts/twitter/src/app/login/_components/password-modal.tsx
+++ b/ts/twitter/src/app/login/_components/password-modal.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Button } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import type React from "react";
+
+export const PasswordModal: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <Button
+      onClick={() => router.push("/home")}
+      fontSize="lg"
+      borderRadius="full"
+      bg="white"
+      color="black"
+      fontWeight="bold"
+    >
+      Login
+    </Button>
+  );
+};

--- a/ts/twitter/src/app/login/page.tsx
+++ b/ts/twitter/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { LoginModal } from "./_components/login-modal";
+
+export default function Page() {
+  return <LoginModal />;
+}


### PR DESCRIPTION
## Issue Number
#598 

## Implementation Summary
Implement login screen modals for auth task.

## Scope of Impact
You can view 2 modals with login path.

## Particular points to check

- Check if the login directory structure is correct. 
- Verify that the following screen appears when accessing http://localhost:3000/login. 
![image](https://github.com/user-attachments/assets/f32de50e-b4af-4314-9ebe-52345cfc863b)
- Confirm that clicking "next" displays the subsequent screen. 
![image](https://github.com/user-attachments/assets/082c9227-ceed-469f-9120-0bfdc6174b1d)
- Ensure that clicking "login" redirects to the home path.

## Schedule
3/15