### PR TITLE
[Go] Implement timeline feature flag

### DIFF
--- a/go/.env.sample
+++ b/go/.env.sample
@@ -22,3 +22,6 @@ APP_PORT="80"
 
 # X-App secret key
 SECRET_KEY="secret-key"
+
+# Timeline feature flags
+USE_NEW_SCHEMA="true"

--- a/go/internal/lib/featureflag/timeline.go
+++ b/go/internal/lib/featureflag/timeline.go
@@ -1,0 +1,40 @@
+package featureflag
+
+import (
+	"os"
+	"sync"
+)
+
+type timelineFeatureFlag struct {
+	UseNewSchema bool
+}
+
+const (
+	useNewSchemaEnvKey = "USE_NEW_SCHEMA"
+)
+
+var (
+	timelineFeatureFlagInstance *timelineFeatureFlag
+	once                        sync.Once
+)
+
+func TimelineFeatureFlag() *timelineFeatureFlag {
+	once.Do(func() {
+		timelineFeatureFlagInstance = &timelineFeatureFlag{
+			UseNewSchema: booleanFlag(false, useNewSchemaEnvKey),
+		}
+	})
+	return timelineFeatureFlagInstance
+}
+
+func booleanFlag(defaultValue bool, envName string) bool {
+	envValue := os.Getenv(envName)
+	switch envValue {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		return defaultValue
+	}
+}

--- a/go/internal/lib/featureflag/timeline_test.go
+++ b/go/internal/lib/featureflag/timeline_test.go
@@ -1,0 +1,37 @@
+package featureflag
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestTimelineFeatureFlag(t *testing.T) {
+	t.Run("Default value (false)", func(t *testing.T) {
+		t.Cleanup(func() {
+			once = sync.Once{}
+		})
+		if TimelineFeatureFlag().UseNewSchema {
+			t.Error("Expected UseNewSchema to be false, but got true")
+		}
+	})
+
+	t.Run("Environment variable set to true", func(t *testing.T) {
+		t.Cleanup(func() {
+			once = sync.Once{}
+		})
+		t.Setenv(useNewSchemaEnvKey, "true")
+		if !TimelineFeatureFlag().UseNewSchema {
+			t.Error("Expected UseNewSchema to be true, but got false")
+		}
+	})
+
+	t.Run("Environment variable set to false", func(t *testing.T) {
+		t.Cleanup(func() {
+			once = sync.Once{}
+		})
+		t.Setenv(useNewSchemaEnvKey, "false")
+		if TimelineFeatureFlag().UseNewSchema {
+			t.Error("Expected UseNewSchema to be false, but got true")
+		}
+	})
+}


### PR DESCRIPTION
## Issue Number
#600 

## Implementation Summary
This PR implements a timeline feature flag to control the process flow based on the environment variable. The `UseNewSchema` flag is designed to make timeline-related functions use the new database schema temporarily until the old schema is fully replaced.

The callers use the flag as follows:
```go
if TimeleingFeatureFlag().UseNewSchema {
    // Do something with the new database schema.
} else {
    // Do something with the old one.
}
```

The `sync.Once` is used to lazily load the environment variable and enforce the singleton pattern. This ensures that the flag is initialized only once during the process lifecycle while maintaining thread safety.

## Scope of Impact
When `TimelineFeatureFlag` is called at first, the instance is created and loads the environment variable. If it's not set, the instance uses the default value.

## Particular points to check
Please verify whether the logic for initializing the instance and retrieving the flag value is implemented correctly.

## Test
`go/internal/lib/featureflag/timeline_test.go` tests the functionality of `TimelineFeaturFlag`.

## Schedule
3/14
