### PR TITLE
[iOS] Implement Real Time UI Updates for Fetched Posts with SSE

### DIFF
--- a/swift/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
+++ b/swift/Twitter-iOS/Twitter-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3B20B0692C3D83E20045E904 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20B0682C3D83E20045E904 /* SearchResultViewController.swift */; };
 		3B20B06F2C3D89A70045E904 /* SearchResultTabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B20B06E2C3D89A70045E904 /* SearchResultTabModel.swift */; };
 		3B2AE47A2D841D35009F4601 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2AE4792D841D2D009F4601 /* TimelineService.swift */; };
+		3B2AE4962D87F17B009F4601 /* TimelinePostsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2AE4952D87F17B009F4601 /* TimelinePostsDataSource.swift */; };
 		3B30345E2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30345D2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift */; };
 		3B3ADDCF2D4F6F9D00934445 /* UserProfileTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3ADDCE2D4F6F9D00934445 /* UserProfileTabViewController.swift */; };
 		3B3ADDD12D508D6800934445 /* UserPostsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3ADDD02D508D6800934445 /* UserPostsCollectionViewCell.swift */; };
@@ -176,6 +177,7 @@
 		3B20B0682C3D83E20045E904 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		3B20B06E2C3D89A70045E904 /* SearchResultTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTabModel.swift; sourceTree = "<group>"; };
 		3B2AE4792D841D2D009F4601 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
+		3B2AE4952D87F17B009F4601 /* TimelinePostsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePostsDataSource.swift; sourceTree = "<group>"; };
 		3B30345D2C1D3B2400FF1C5E /* NotificationsVerifiedTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsVerifiedTabView.swift; sourceTree = "<group>"; };
 		3B3ADDCE2D4F6F9D00934445 /* UserProfileTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTabViewController.swift; sourceTree = "<group>"; };
 		3B3ADDD02D508D6800934445 /* UserPostsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPostsCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -504,6 +506,7 @@
 				656C1BFC2C08A16C00EEE575 /* HomeTabView.swift */,
 				6540F8CA2BB57A8B0029BA46 /* HomeViewController.swift */,
 				65FD4FAE2C2AE0270020A02E /* NSNotification+Home.swift */,
+				3B2AE4952D87F17B009F4601 /* TimelinePostsDataSource.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1342,6 +1345,7 @@
 				3B5CE8522C74D683005833E1 /* AltTextEditViewController.swift in Sources */,
 				65FD4FDC2C3039580020A02E /* SubscriptionService.swift in Sources */,
 				65C6CC272BFB70E400B0A052 /* UIViewController+Settings.swift in Sources */,
+				3B2AE4962D87F17B009F4601 /* TimelinePostsDataSource.swift in Sources */,
 				65C6CC2D2BFCC51F00B0A052 /* CGFloat+Rect.swift in Sources */,
 				65C6CC202BF9625E00B0A052 /* BannerView.swift in Sources */,
 				65C71BA62C342EC90025839C /* JobsSearchTabView.swift in Sources */,

--- a/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeTabView.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Home/HomeTabView.swift
@@ -6,14 +6,7 @@ struct HomeTabView: View {
   @Binding public var postToRepost: PostModel?
   @Binding public var showShareSheet: Bool
   @Binding public var urlStrToOpen: String
-
-  @State private var postModels: [PostModel] = {
-    var models: [PostModel] = []
-    for _ in 0..<20 {
-      models.append(createFakePostModel())
-    }
-    return models
-  }()
+  @Binding public var postModels: [PostModel]
 
   @State private var isMuteAlertPresented = false
 
@@ -131,6 +124,7 @@ struct HomeTabView: View {
     reposting: .constant(false),
     postToRepost: .constant(nil),
     showShareSheet: .constant(false),
-    urlStrToOpen: .constant("")
+    urlStrToOpen: .constant(""),
+    postModels: .constant(createFakeTimelinePostsDataSource().followingTabPostModels)
   )
 }

--- a/swift/Twitter-iOS/Twitter-iOS/Features/Home/TimelinePostsDataSource.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Features/Home/TimelinePostsDataSource.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The data source of posts data for each tab in HomeViewController.
+final class TimelinePostsDataSource: ObservableObject {
+  @Published var forYouTabPostModels: [PostModel] = []
+  @Published var followingTabPostModels: [PostModel] = []
+}
+
+/// Create a timeline posts data source for preview and testing purposes.
+///
+/// - Returns: The TimelinePostsDataSource instance with sample data.
+func createFakeTimelinePostsDataSource() -> TimelinePostsDataSource {
+  let dataSource = TimelinePostsDataSource()
+
+  var forYouTabPostModels = [PostModel]()
+  for _ in 0..<30 {
+    forYouTabPostModels.append(createFakePostModel())
+  }
+  dataSource.forYouTabPostModels = forYouTabPostModels
+
+  var followingTabPostModels = [PostModel]()
+  for _ in 0..<30 {
+    followingTabPostModels.append(createFakePostModel())
+  }
+  dataSource.followingTabPostModels = followingTabPostModels
+
+  return dataSource
+}

--- a/swift/Twitter-iOS/Twitter-iOS/Services/Timeline/TimelineService.swift
+++ b/swift/Twitter-iOS/Twitter-iOS/Services/Timeline/TimelineService.swift
@@ -6,14 +6,17 @@ public typealias didStartListeningToTimelineSSECompletion = (
 ) -> Void
 
 /// The enum to represent the errors in TimelineService.
-private enum TimelineServiceError: Error {
-  case invalidURL
+public enum TimelineServiceError: Error {
+  case invalidURLError
   case dataProcessingError
 }
 
-/// The service class to handle timeline-related operations.
 // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/612
 // - Implement Unit Tests for TimelineService.
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/615
+// - Implement Reconnection Logic for SSE Connection in TimelineService.
+/// The service class to handle timeline-related operations.
 public final class TimelineService: NSObject {
 
   // MARK: - Public Props
@@ -51,7 +54,7 @@ public final class TimelineService: NSObject {
       let url = URL(
         string: "\(TimelineService.baseURL)/api/users/\(id)/timelines/reverse_chronological")
     else {
-      completion(.failure(TimelineServiceError.invalidURL))
+      completion(.failure(TimelineServiceError.invalidURLError))
       return
     }
 


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/584

## Implementation Summary
This PR implements real-time UI updates for fetched posts using the timeline Server-sent events (SSE) connection. This enables users to view their posts in the "Following" tab within `HomeViewController`.

## Scope of Impact
Users will now see posts fetched from the server in the Following tab of HomeViewController. Additionally, when a new post is created, it will automatically appear at the top of the "Following" tab.

## Particular points to check
Please review whether the post updating logic and error handling logic are appropriate.

## Reference
https://github.com/user-attachments/assets/5a8f63cb-9392-4cb3-a6e4-3c84c0d3712a

## Schedule
Until 3/22.
