### PR TITLE
[Go] Implement reposts using the selected approach

### DIFF
--- a/go/db/migrations/000012_update_posts_table.down.sql
+++ b/go/db/migrations/000012_update_posts_table.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts
+DROP CONSTRAINT fk_user;

--- a/go/db/migrations/000012_update_posts_table.up.sql
+++ b/go/db/migrations/000012_update_posts_table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts
+ADD CONSTRAINT fk_user FOREIGN KEY ("user_id") REFERENCES users("id") ON DELETE CASCADE;

--- a/go/internal/application/usecase/interactor/specific_user_posts.go
+++ b/go/internal/application/usecase/interactor/specific_user_posts.go
@@ -1,0 +1,24 @@
+package interactor
+
+import (
+	"x-clone-backend/internal/application/usecase"
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+)
+
+type specificUserPostsUsecase struct {
+	timelineitemsRepository repository.TimelineItemsRepository
+}
+
+func NewSpecificUserPostsUsecase(timelineitemsRepository repository.TimelineItemsRepository) usecase.SpecificUserPostsUsecase {
+	return &specificUserPostsUsecase{timelineitemsRepository: timelineitemsRepository}
+}
+
+func (p *specificUserPostsUsecase) SpecificUserPosts(userID string) ([]*entity.TimelineItem, error) {
+	timelineitems, err := p.timelineitemsRepository.SpecificUserPosts(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return timelineitems, nil
+}

--- a/go/internal/application/usecase/interactor/users_and_followee_posts.go
+++ b/go/internal/application/usecase/interactor/users_and_followee_posts.go
@@ -1,0 +1,24 @@
+package interactor
+
+import (
+	"x-clone-backend/internal/application/usecase"
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+)
+
+type userAndFolloweePostsUsecase struct {
+	timelineitemsRepository repository.TimelineItemsRepository
+}
+
+func NewUserAndFolloweePostsUsecase(timelineitemsRepository repository.TimelineItemsRepository) usecase.UserAndFolloweePostsUsecase {
+	return &userAndFolloweePostsUsecase{timelineitemsRepository: timelineitemsRepository}
+}
+
+func (p *userAndFolloweePostsUsecase) UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error) {
+	timelineitems, err := p.timelineitemsRepository.UserAndFolloweePosts(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return timelineitems, nil
+}

--- a/go/internal/application/usecase/specific_user_posts.go
+++ b/go/internal/application/usecase/specific_user_posts.go
@@ -1,0 +1,9 @@
+package usecase
+
+import (
+	"x-clone-backend/internal/domain/entity"
+)
+
+type SpecificUserPostsUsecase interface {
+	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
+}

--- a/go/internal/application/usecase/users_and_followee_posts.go
+++ b/go/internal/application/usecase/users_and_followee_posts.go
@@ -1,0 +1,9 @@
+package usecase
+
+import (
+	"x-clone-backend/internal/domain/entity"
+)
+
+type UserAndFolloweePostsUsecase interface {
+	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
+}

--- a/go/internal/controller/handler/create_post_test.go
+++ b/go/internal/controller/handler/create_post_test.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"x-clone-backend/internal/lib/featureflag"
+
+	"github.com/google/uuid"
+)
+
+func (s *handlerTestSuite) TestCreatePost() {
+	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
+
+	tests := []struct {
+		name         string
+		userID       string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "create post",
+			body:         fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "invalid JSON body",
+			body:         fmt.Sprintf(`{ "user_id": "%s, "text": "test" }`, userID),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "invalid body",
+			body:         `{ "text": "test" }`,
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "non-existent user id",
+			body:         fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, uuid.New().String()),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest(
+			"POST",
+			"/api/posts/",
+			strings.NewReader(test.body),
+		)
+		rr := httptest.NewRecorder()
+
+		createPostHandler := NewCreatePostHandler(s.db, &s.mu, &s.userChannels)
+		createPostHandler.CreatePost(rr, req)
+
+		if rr.Code != test.expectedCode {
+			s.T().Errorf("%s: wrong code returned; expected %d, but got %d", test.name, test.expectedCode, rr.Code)
+		}
+	}
+}
+
+func (s *handlerTestSuite) TestCreatePost_UseNewSchema() {
+	featureflag.ResetTimelineFeatureFlag()
+	s.T().Setenv(featureflag.UseNewSchemaEnvKey, "true")
+	s.T().Cleanup(func() {
+		featureflag.ResetTimelineFeatureFlag()
+	})
+	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
+
+	tests := []struct {
+		name         string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "create post",
+			body:         fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "invalid JSON body",
+			body:         fmt.Sprintf(`{ "user_id": "%s, "text": "test" }`, userID),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "invalid body",
+			body:         `{ "text": "test" }`,
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "non-existent user id",
+			body:         fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, uuid.New().String()),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest(
+			"POST",
+			"/api/posts/",
+			strings.NewReader(test.body),
+		)
+		rr := httptest.NewRecorder()
+
+		createPostHandler := NewCreatePostHandler(s.db, &s.mu, &s.userChannels)
+		createPostHandler.CreatePost(rr, req)
+
+		if rr.Code != test.expectedCode {
+			s.T().Errorf("%s: wrong code returned; expected %d, but got %d", test.name, test.expectedCode, rr.Code)
+		}
+	}
+}

--- a/go/internal/controller/handler/create_quote_repost.go
+++ b/go/internal/controller/handler/create_quote_repost.go
@@ -14,6 +14,7 @@ import (
 
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/value"
+	"x-clone-backend/internal/lib/featureflag"
 	"x-clone-backend/internal/openapi"
 )
 
@@ -55,90 +56,158 @@ func (h *CreateQuoteRepostHandler) CreateQuoteRepost(w http.ResponseWriter, r *h
 		return
 	}
 
-	query := `
-		SELECT 
-			r.id IS NOT NULL AS is_parent_repost
-		FROM users u
-		LEFT JOIN reposts r ON r.id = $2
-		WHERE u.id = $1
-	`
-	var isParentRepost bool
-	err = h.db.QueryRow(query, userID, PostID).Scan(&isParentRepost)
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			http.Error(w, "User not found.", http.StatusBadRequest)
-		default:
-			http.Error(w, "Database query error.", http.StatusInternalServerError)
-		}
-		return
-	}
+	if featureflag.TimelineFeatureFlag().UseNewSchema {
+		query := `INSERT INTO timelineitems (type, author_id, parent_post_id ,text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
 
-	if isParentRepost {
-		query = `INSERT INTO reposts (user_id, parent_repost_id, is_quote, text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
-	} else {
-		query = `INSERT INTO reposts (user_id, parent_post_id, is_quote, text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
-	}
+		var (
+			id        uuid.UUID
+			createdAt time.Time
+		)
 
-	var (
-		id        uuid.UUID
-		createdAt time.Time
-	)
+		postType := entity.PostTypeQuoteRepost
 
-	isQuote := true
-
-	err = h.db.QueryRow(query, userID, PostID, isQuote, body.Text).Scan(&id, &createdAt)
-	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not create a quote repost."), http.StatusInternalServerError)
-		return
-	}
-
-	quoteRepost := entity.Repost{
-		ID:        id,
-		ParentID:  PostID,
-		UserID:    userID,
-		Text:      body.Text,
-		CreatedAt: createdAt,
-	}
-
-	go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
-		var quoteReposts []*entity.Repost
-		quoteReposts = append(quoteReposts, &quoteRepost)
-		query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
-		rows, err := h.db.Query(query, userID.String())
+		err = h.db.QueryRow(query, postType, userID, PostID, body.Text).Scan(&id, &createdAt)
 		if err != nil {
-			log.Fatalln(err)
+			http.Error(w, fmt.Sprintln("Could not create a quote repost."), http.StatusInternalServerError)
 			return
 		}
 
-		var ids []uuid.UUID
-		for rows.Next() {
-			var id uuid.UUID
-			if err := rows.Scan(&id); err != nil {
+		quoteRepost := entity.TimelineItem{
+			Type:         postType,
+			ID:           id,
+			AuthorID:     userID,
+			ParentPostID: uuid.NullUUID{UUID: PostID, Valid: true},
+			Text:         body.Text,
+			CreatedAt:    createdAt,
+		}
+
+		go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
+			var quoteReposts []*entity.TimelineItem
+			quoteReposts = append(quoteReposts, &quoteRepost)
+			query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
+			rows, err := h.db.Query(query, userID.String())
+			if err != nil {
 				log.Fatalln(err)
 				return
 			}
 
-			ids = append(ids, id)
-		}
-		ids = append(ids, userID)
-		for _, id := range ids {
-			h.mu.Lock()
-			if userChan, ok := (*h.usersChan)[id.String()]; ok {
-				userChan <- value.TimelineEvent{EventType: value.QuoteRepostCreated, Reposts: quoteReposts}
+			var ids []uuid.UUID
+			for rows.Next() {
+				var id uuid.UUID
+				if err := rows.Scan(&id); err != nil {
+					log.Fatalln(err)
+					return
+				}
+
+				ids = append(ids, id)
 			}
-			h.mu.Unlock()
+			ids = append(ids, userID)
+			for _, id := range ids {
+				h.mu.Lock()
+				if userChan, ok := (*h.usersChan)[id.String()]; ok {
+					userChan <- value.TimelineEvent{EventType: value.QuoteRepostCreated, TimelineItems: quoteReposts}
+				}
+				h.mu.Unlock()
+			}
+
+		}(userID, h.usersChan)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		encoder := json.NewEncoder(w)
+		err = encoder.Encode(&quoteRepost)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		query := `
+			SELECT 
+				r.id IS NOT NULL AS is_parent_repost
+			FROM users u
+			LEFT JOIN reposts r ON r.id = $2
+			WHERE u.id = $1
+		`
+		var isParentRepost bool
+		err = h.db.QueryRow(query, userID, PostID).Scan(&isParentRepost)
+		if err != nil {
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				http.Error(w, "User not found.", http.StatusBadRequest)
+			default:
+				http.Error(w, "Database query error.", http.StatusInternalServerError)
+			}
+			return
 		}
 
-	}(userID, h.usersChan)
+		if isParentRepost {
+			query = `INSERT INTO reposts (user_id, parent_repost_id, is_quote, text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
+		} else {
+			query = `INSERT INTO reposts (user_id, parent_post_id, is_quote, text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
+		}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+		var (
+			id        uuid.UUID
+			createdAt time.Time
+		)
 
-	encoder := json.NewEncoder(w)
-	err = encoder.Encode(&quoteRepost)
-	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
-		return
+		isQuote := true
+
+		err = h.db.QueryRow(query, userID, PostID, isQuote, body.Text).Scan(&id, &createdAt)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not create a quote repost."), http.StatusInternalServerError)
+			return
+		}
+
+		quoteRepost := entity.Repost{
+			ID:        id,
+			ParentID:  PostID,
+			UserID:    userID,
+			Text:      body.Text,
+			CreatedAt: createdAt,
+		}
+
+		go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
+			var quoteReposts []*entity.Repost
+			quoteReposts = append(quoteReposts, &quoteRepost)
+			query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
+			rows, err := h.db.Query(query, userID.String())
+			if err != nil {
+				log.Fatalln(err)
+				return
+			}
+
+			var ids []uuid.UUID
+			for rows.Next() {
+				var id uuid.UUID
+				if err := rows.Scan(&id); err != nil {
+					log.Fatalln(err)
+					return
+				}
+
+				ids = append(ids, id)
+			}
+			ids = append(ids, userID)
+			for _, id := range ids {
+				h.mu.Lock()
+				if userChan, ok := (*h.usersChan)[id.String()]; ok {
+					userChan <- value.TimelineEvent{EventType: value.QuoteRepostCreated, Reposts: quoteReposts}
+				}
+				h.mu.Unlock()
+			}
+
+		}(userID, h.usersChan)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		encoder := json.NewEncoder(w)
+		err = encoder.Encode(&quoteRepost)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
+			return
+		}
 	}
+
 }

--- a/go/internal/controller/handler/create_quote_repost_test.go
+++ b/go/internal/controller/handler/create_quote_repost_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"x-clone-backend/internal/lib/featureflag"
+
 	"github.com/google/uuid"
 )
 
@@ -49,6 +51,77 @@ func (s *handlerTestSuite) TestCreateQuoteRepost() {
 			userID:       uuid.New().String(),
 			body:         fmt.Sprintf(`{ "post_id": "%s", "text": "test" }`, postID),
 			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "non-existent post id",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s", "text": "test" }`, uuid.New()),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest(
+			"POST",
+			fmt.Sprintf("/api/users/%s/quote_reposts", test.userID),
+			strings.NewReader(test.body),
+		)
+		rr := httptest.NewRecorder()
+
+		createRepostHandler := NewCreateQuoteRepostHandler(s.db, &s.mu, &s.userChannels)
+		createRepostHandler.CreateQuoteRepost(rr, req, test.userID)
+
+		if rr.Code != test.expectedCode {
+			s.T().Errorf("%s: wrong code returned; expected %d, but got %d", test.name, test.expectedCode, rr.Code)
+		}
+	}
+}
+
+func (s *handlerTestSuite) TestCreateQuoteRepost_UseNewSchema() {
+	featureflag.ResetTimelineFeatureFlag()
+	s.T().Setenv(featureflag.UseNewSchemaEnvKey, "true")
+	s.T().Cleanup(func() {
+		featureflag.ResetTimelineFeatureFlag()
+	})
+	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
+	postID := s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID))
+	repostID := s.newTestQuoteRepost(userID, postID)
+
+	tests := []struct {
+		name         string
+		userID       string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "create quote repost from a post",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s", "text": "test" }`, postID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "create quote repost from a quote repost",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s", "text": "test" }`, repostID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "invalid JSON body",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s, "text": "test" }`, postID),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "invalid body",
+			userID:       userID,
+			body:         `{"text": "test"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "non-existent user id",
+			userID:       uuid.New().String(),
+			body:         fmt.Sprintf(`{ "post_id": "%s", "text": "test" }`, postID),
+			expectedCode: http.StatusInternalServerError,
 		},
 		{
 			name:         "non-existent post id",

--- a/go/internal/controller/handler/create_repost.go
+++ b/go/internal/controller/handler/create_repost.go
@@ -14,6 +14,7 @@ import (
 
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/value"
+	"x-clone-backend/internal/lib/featureflag"
 	"x-clone-backend/internal/openapi"
 )
 
@@ -55,90 +56,159 @@ func (h *CreateRepostHandler) CreateRepost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	query := `
-		SELECT
-			r.id IS NOT NULL AS is_parent_repost
-		FROM users u
-		LEFT JOIN reposts r ON r.id = $2
-		WHERE u.id = $1
-	`
-	var isParentRepost bool
-	err = h.db.QueryRow(query, userID, PostID).Scan(&isParentRepost)
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			http.Error(w, "User not found.", http.StatusBadRequest)
-		default:
-			http.Error(w, "Database query error.", http.StatusInternalServerError)
-		}
-		return
-	}
+	if featureflag.TimelineFeatureFlag().UseNewSchema {
+		query := `INSERT INTO timelineitems (type, author_id, parent_post_id ,text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
 
-	if isParentRepost {
-		query = `INSERT INTO reposts (user_id, parent_repost_id, text) VALUES ($1, $2, $3) RETURNING id, created_at`
-	} else {
-		query = `INSERT INTO reposts (user_id, parent_post_id, text) VALUES ($1, $2, $3) RETURNING id, created_at`
-	}
+		var (
+			id        uuid.UUID
+			createdAt time.Time
+		)
 
-	var (
-		id        uuid.UUID
-		createdAt time.Time
-	)
+		postType := entity.PostTypeRepost
+		text := ""
 
-	text := ""
-
-	err = h.db.QueryRow(query, userID, PostID, text).Scan(&id, &createdAt)
-	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not create a repost."), http.StatusInternalServerError)
-		return
-	}
-
-	repost := entity.Repost{
-		ID:        id,
-		ParentID:  PostID,
-		UserID:    userID,
-		Text:      text,
-		CreatedAt: createdAt,
-	}
-
-	go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
-		var reposts []*entity.Repost
-		reposts = append(reposts, &repost)
-		query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
-		rows, err := h.db.Query(query, userID.String())
+		err = h.db.QueryRow(query, postType, userID, PostID, text).Scan(&id, &createdAt)
 		if err != nil {
-			log.Fatalln(err)
+			http.Error(w, fmt.Sprintln("Could not create a repost."), http.StatusInternalServerError)
 			return
 		}
 
-		var ids []uuid.UUID
-		for rows.Next() {
-			var id uuid.UUID
-			if err := rows.Scan(&id); err != nil {
+		repost := entity.TimelineItem{
+			Type:         postType,
+			ID:           id,
+			AuthorID:     userID,
+			ParentPostID: uuid.NullUUID{UUID: PostID, Valid: true},
+			Text:         text,
+			CreatedAt:    createdAt,
+		}
+
+		go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
+			var reposts []*entity.TimelineItem
+			reposts = append(reposts, &repost)
+			query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
+			rows, err := h.db.Query(query, userID.String())
+			if err != nil {
 				log.Fatalln(err)
 				return
 			}
 
-			ids = append(ids, id)
-		}
-		ids = append(ids, userID)
-		for _, id := range ids {
-			h.mu.Lock()
-			if userChan, ok := (*h.usersChan)[id.String()]; ok {
-				userChan <- value.TimelineEvent{EventType: value.RepostCreated, Reposts: reposts}
+			var ids []uuid.UUID
+			for rows.Next() {
+				var id uuid.UUID
+				if err := rows.Scan(&id); err != nil {
+					log.Fatalln(err)
+					return
+				}
+
+				ids = append(ids, id)
 			}
-			h.mu.Unlock()
+			ids = append(ids, userID)
+			for _, id := range ids {
+				h.mu.Lock()
+				if userChan, ok := (*h.usersChan)[id.String()]; ok {
+					userChan <- value.TimelineEvent{EventType: value.RepostCreated, TimelineItems: reposts}
+				}
+				h.mu.Unlock()
+			}
+
+		}(userID, h.usersChan)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		encoder := json.NewEncoder(w)
+		err = encoder.Encode(&repost)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		query := `
+			SELECT
+				r.id IS NOT NULL AS is_parent_repost
+			FROM users u
+			LEFT JOIN reposts r ON r.id = $2
+			WHERE u.id = $1
+		`
+		var isParentRepost bool
+		err = h.db.QueryRow(query, userID, PostID).Scan(&isParentRepost)
+		if err != nil {
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				http.Error(w, "User not found.", http.StatusBadRequest)
+			default:
+				http.Error(w, "Database query error.", http.StatusInternalServerError)
+			}
+			return
 		}
 
-	}(userID, h.usersChan)
+		if isParentRepost {
+			query = `INSERT INTO reposts (user_id, parent_repost_id, text) VALUES ($1, $2, $3) RETURNING id, created_at`
+		} else {
+			query = `INSERT INTO reposts (user_id, parent_post_id, text) VALUES ($1, $2, $3) RETURNING id, created_at`
+		}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+		var (
+			id        uuid.UUID
+			createdAt time.Time
+		)
 
-	encoder := json.NewEncoder(w)
-	err = encoder.Encode(&repost)
-	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
-		return
+		text := ""
+
+		err = h.db.QueryRow(query, userID, PostID, text).Scan(&id, &createdAt)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not create a repost."), http.StatusInternalServerError)
+			return
+		}
+
+		repost := entity.Repost{
+			ID:        id,
+			ParentID:  PostID,
+			UserID:    userID,
+			Text:      text,
+			CreatedAt: createdAt,
+		}
+
+		go func(userID uuid.UUID, userChan *map[string]chan value.TimelineEvent) {
+			var reposts []*entity.Repost
+			reposts = append(reposts, &repost)
+			query := `SELECT source_user_id FROM followships WHERE target_user_id = $1`
+			rows, err := h.db.Query(query, userID.String())
+			if err != nil {
+				log.Fatalln(err)
+				return
+			}
+
+			var ids []uuid.UUID
+			for rows.Next() {
+				var id uuid.UUID
+				if err := rows.Scan(&id); err != nil {
+					log.Fatalln(err)
+					return
+				}
+
+				ids = append(ids, id)
+			}
+			ids = append(ids, userID)
+			for _, id := range ids {
+				h.mu.Lock()
+				if userChan, ok := (*h.usersChan)[id.String()]; ok {
+					userChan <- value.TimelineEvent{EventType: value.RepostCreated, Reposts: reposts}
+				}
+				h.mu.Unlock()
+			}
+
+		}(userID, h.usersChan)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		encoder := json.NewEncoder(w)
+		err = encoder.Encode(&repost)
+		if err != nil {
+			http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
+			return
+		}
 	}
+
 }

--- a/go/internal/controller/handler/create_repost_test.go
+++ b/go/internal/controller/handler/create_repost_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"x-clone-backend/internal/lib/featureflag"
+
 	"github.com/google/uuid"
 )
 
@@ -49,6 +51,77 @@ func (s *handlerTestSuite) TestCreateRepost() {
 			userID:       uuid.New().String(),
 			body:         fmt.Sprintf(`{ "post_id": "%s" }`, postID),
 			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "non-existent post id",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s" }`, uuid.New()),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest(
+			"POST",
+			fmt.Sprintf("/api/users/%s/reposts", test.userID),
+			strings.NewReader(test.body),
+		)
+		rr := httptest.NewRecorder()
+
+		createRepostHandler := NewCreateRepostHandler(s.db, &s.mu, &s.userChannels)
+		createRepostHandler.CreateRepost(rr, req, test.userID)
+
+		if rr.Code != test.expectedCode {
+			s.T().Errorf("%s: wrong code returned; expected %d, but got %d", test.name, test.expectedCode, rr.Code)
+		}
+	}
+}
+
+func (s *handlerTestSuite) TestCreateRepost_UseNewSchema() {
+	featureflag.ResetTimelineFeatureFlag()
+	s.T().Setenv(featureflag.UseNewSchemaEnvKey, "true")
+	s.T().Cleanup(func() {
+		featureflag.ResetTimelineFeatureFlag()
+	})
+	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
+	postID := s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID))
+	repostID := s.newTestQuoteRepost(userID, postID)
+
+	tests := []struct {
+		name         string
+		userID       string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "create repost from a post",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s" }`, postID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "create repost from a quote repost",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s" }`, repostID),
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "invalid JSON body",
+			userID:       userID,
+			body:         fmt.Sprintf(`{ "post_id": "%s }`, postID),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "invalid body",
+			userID:       userID,
+			body:         "{}",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "non-existent user id",
+			userID:       uuid.New().String(),
+			body:         fmt.Sprintf(`{ "post_id": "%s" }`, postID),
+			expectedCode: http.StatusInternalServerError,
 		},
 		{
 			name:         "non-existent post id",

--- a/go/internal/controller/handler/delete_repost_test.go
+++ b/go/internal/controller/handler/delete_repost_test.go
@@ -5,9 +5,67 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	"x-clone-backend/internal/lib/featureflag"
 )
 
 func (s *handlerTestSuite) TestDeleteRepost() {
+	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
+	postID := s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID))
+	repostID := s.newTestRepost(userID, postID)
+	quoteRepostID := s.newTestQuoteRepost(userID, postID)
+
+	tests := []struct {
+		name         string
+		parentID     string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "delete repost",
+			parentID:     postID,
+			body:         fmt.Sprintf(`{ "repost_id": "%s" }`, repostID),
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:         "delete quote repost",
+			parentID:     repostID,
+			body:         fmt.Sprintf(`{ "repost_id": "%s" }`, quoteRepostID),
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:         "non-existent repost",
+			parentID:     postID,
+			body:         fmt.Sprintf(`{ "repost_id": "%s" }`, repostID),
+			expectedCode: http.StatusNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			"DELETE",
+			fmt.Sprintf("/api/users/%s/reposts/%s", userID, test.parentID),
+			strings.NewReader(test.body),
+		)
+		req.SetPathValue("user_id", userID)
+		req.SetPathValue("post_id", test.parentID)
+
+		deleteRepostHandler := NewDeleteRepostHandler(s.db, &s.mu, &s.userChannels)
+		deleteRepostHandler.DeleteRepost(rr, req, userID, test.parentID)
+
+		if rr.Code != test.expectedCode {
+			s.T().Errorf("%s: wrong code returned; expected %d, but got %d", test.name, test.expectedCode, rr.Code)
+		}
+	}
+}
+
+func (s *handlerTestSuite) TestDeleteRepost_UseNewSchema() {
+	featureflag.ResetTimelineFeatureFlag()
+	s.T().Setenv(featureflag.UseNewSchemaEnvKey, "true")
+	s.T().Cleanup(func() {
+		featureflag.ResetTimelineFeatureFlag()
+	})
 	userID := s.newTestUser(`{ "username": "test", "display_name": "test", "password": "securepassword" }`)
 	postID := s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test" }`, userID))
 	repostID := s.newTestRepost(userID, postID)

--- a/go/internal/controller/handler/get_user_posts_timeline.go
+++ b/go/internal/controller/handler/get_user_posts_timeline.go
@@ -8,31 +8,51 @@ import (
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/application/usecase/interactor"
 	"x-clone-backend/internal/infrastructure/persistence"
+	"x-clone-backend/internal/lib/featureflag"
 )
 
 type GetUserPostsTimelineHandler struct {
 	getSpecificUserPostsUsecase usecase.GetSpecificUserPostsUsecase
+	specificUserPostsUsecase    usecase.SpecificUserPostsUsecase
 }
 
 func NewGetUserPostsTimelineHandler(db *sql.DB) GetUserPostsTimelineHandler {
 	postsRepository := persistence.NewPostsRepository(db)
 	getSpecificUserPostsUsecase := interactor.NewGetSpecificUserPostsUsecase(postsRepository)
+	timelineitemsRepository := persistence.NewTimelineitemsRepository(db)
+	specificUserPostsUsecase := interactor.NewSpecificUserPostsUsecase(timelineitemsRepository)
 	return GetUserPostsTimelineHandler{
 		getSpecificUserPostsUsecase: getSpecificUserPostsUsecase,
+		specificUserPostsUsecase:    specificUserPostsUsecase,
 	}
 }
 
 // GetUserPostsTimeline gets posts by a single user, specified by the requested user ID.
 func (h *GetUserPostsTimelineHandler) GetUserPostsTimeline(w http.ResponseWriter, r *http.Request, id string) {
-	posts, err := h.getSpecificUserPostsUsecase.GetSpecificUserPosts(id)
-	if err != nil {
-		http.Error(w, "Failed to get posts", http.StatusInternalServerError)
+	if featureflag.TimelineFeatureFlag().UseNewSchema {
+		timelineitems, err := h.specificUserPostsUsecase.SpecificUserPosts(id)
+		if err != nil {
+			http.Error(w, "Failed to get timelineitems", http.StatusInternalServerError)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		encoder := json.NewEncoder(w)
+		if err := encoder.Encode(timelineitems); err != nil {
+			http.Error(w, "Failed to convert to json", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		posts, err := h.getSpecificUserPostsUsecase.GetSpecificUserPosts(id)
+		if err != nil {
+			http.Error(w, "Failed to get posts", http.StatusInternalServerError)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		encoder := json.NewEncoder(w)
+		if err := encoder.Encode(posts); err != nil {
+			http.Error(w, "Failed to convert to json", http.StatusInternalServerError)
+			return
+		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	encoder := json.NewEncoder(w)
-	if err := encoder.Encode(posts); err != nil {
-		http.Error(w, "Failed to convert to json", http.StatusInternalServerError)
-		return
-	}
 }

--- a/go/internal/controller/handler/get_user_posts_timeline_test.go
+++ b/go/internal/controller/handler/get_user_posts_timeline_test.go
@@ -7,9 +7,64 @@ import (
 	"strings"
 
 	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/lib/featureflag"
 )
 
 func (s *handlerTestSuite) TestGetUserPostsTimeline() {
+	// This test method verifies the number of posts in the response body.
+	user1ID := s.newTestUser(`{ "username": "test1", "display_name": "test1", "password": "securepassword" }`)
+	_ = s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test1" }`, user1ID))
+	user2ID := s.newTestUser(`{ "username": "test2", "display_name": "test2", "password": "securepassword" }`)
+
+	tests := []struct {
+		name          string
+		userID        string
+		expectedCount int
+	}{
+		{
+			name:          "get user posts",
+			userID:        user1ID,
+			expectedCount: 1,
+		},
+		{
+			name:          "get no posts",
+			userID:        user2ID,
+			expectedCount: 0,
+		},
+	}
+
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			"GET",
+			"/api/users/{id}/posts",
+			strings.NewReader(""),
+		)
+		req.SetPathValue("id", test.userID)
+
+		getUserPostsTimelineHandler := NewGetUserPostsTimelineHandler(s.db)
+		getUserPostsTimelineHandler.GetUserPostsTimeline(rr, req, test.userID)
+
+		var posts []*entity.Post
+
+		decoder := json.NewDecoder(rr.Body)
+		err := decoder.Decode(&posts)
+		if err != nil {
+			s.T().Errorf("%s: failed to decode response", test.name)
+		}
+
+		if len(posts) != test.expectedCount {
+			s.T().Errorf("%s: wrong number of posts returned; expected %d, but got %d", test.name, test.expectedCount, len(posts))
+		}
+	}
+}
+
+func (s *handlerTestSuite) TestGetUserPostsTimeline_UseNewSchema() {
+	featureflag.ResetTimelineFeatureFlag()
+	s.T().Setenv(featureflag.UseNewSchemaEnvKey, "true")
+	s.T().Cleanup(func() {
+		featureflag.ResetTimelineFeatureFlag()
+	})
 	// This test method verifies the number of posts in the response body.
 	user1ID := s.newTestUser(`{ "username": "test1", "display_name": "test1", "password": "securepassword" }`)
 	_ = s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test1" }`, user1ID))

--- a/go/internal/controller/handler/setup_test.go
+++ b/go/internal/controller/handler/setup_test.go
@@ -77,8 +77,10 @@ type handlerTestSuite struct {
 	db                             *sql.DB
 	resource                       *dockertest.Resource
 	getSpecificUserPostsUsecase    usecase.GetSpecificUserPostsUsecase
+	specificUserPostsUsecase       usecase.SpecificUserPostsUsecase
 	loginUseCase                   usecase.LoginUsecase
 	getUserAndFolloweePostsUsecase usecase.GetUserAndFolloweePostsUsecase
+	userAndFolloweePostsUsecase    usecase.UserAndFolloweePostsUsecase
 	usersRepository                repository.UsersRepository
 	createUserUsecase              usecase.CreateUserUsecase
 	authService                    *service.AuthService
@@ -131,6 +133,10 @@ func (s *handlerTestSuite) SetupTest() {
 	s.getSpecificUserPostsUsecase = interactor.NewGetSpecificUserPostsUsecase(postsRepository)
 	s.loginUseCase = interactor.NewLoginUseCase(s.usersRepository, s.authService)
 	s.getUserAndFolloweePostsUsecase = interactor.NewGetUserAndFolloweePostsUsecase(postsRepository)
+
+	timelineitemsRepository := persistence.NewTimelineitemsRepository(s.db)
+	s.specificUserPostsUsecase = interactor.NewSpecificUserPostsUsecase(timelineitemsRepository)
+	s.userAndFolloweePostsUsecase = interactor.NewUserAndFolloweePostsUsecase(timelineitemsRepository)
 
 	s.usersRepository = persistence.NewUsersRepository(s.db)
 	s.createUserUsecase = interactor.NewCreateUserUsecase(s.usersRepository)

--- a/go/internal/domain/entity/timelineitem.go
+++ b/go/internal/domain/entity/timelineitem.go
@@ -1,0 +1,25 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	PostTypePost        = "post"
+	PostTypeRepost      = "repost"
+	PostTypeQuoteRepost = "quoteRepost"
+)
+
+// TimelineItem represents an entry of `timelineitems` table.
+// It contains properties such as Type, ID, AuthorID, ParentPostID, Text, and CreatedAt.
+// AuthorID is the ID of the author of the timeline item.
+type TimelineItem struct {
+	Type         string        `json:"type"`
+	ID           uuid.UUID     `json:"id"`
+	AuthorID     uuid.UUID     `json:"authorId"`
+	ParentPostID uuid.NullUUID `json:"parentPostId,omitzero"`
+	Text         string        `json:"text,omitzero"`
+	CreatedAt    time.Time     `json:"createdAt"`
+}

--- a/go/internal/domain/repository/timelineitems.go
+++ b/go/internal/domain/repository/timelineitems.go
@@ -1,0 +1,10 @@
+package repository
+
+import (
+	"x-clone-backend/internal/domain/entity"
+)
+
+type TimelineItemsRepository interface {
+	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
+	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
+}

--- a/go/internal/domain/value/timeline_event.go
+++ b/go/internal/domain/value/timeline_event.go
@@ -12,7 +12,8 @@ const (
 )
 
 type TimelineEvent struct {
-	EventType string           `json:"event_type"`
-	Posts     []*entity.Post   `json:"posts"`
-	Reposts   []*entity.Repost `json:"reposts"`
+	EventType     string                 `json:"event_type"`
+	Posts         []*entity.Post         `json:"posts"`
+	Reposts       []*entity.Repost       `json:"reposts"`
+	TimelineItems []*entity.TimelineItem `json:"timeline_items"`
 }

--- a/go/internal/infrastructure/persistence/timelineitems.go
+++ b/go/internal/infrastructure/persistence/timelineitems.go
@@ -1,0 +1,99 @@
+package persistence
+
+import (
+	"database/sql"
+	"time"
+
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+
+	"github.com/google/uuid"
+)
+
+type timelineitemsRepository struct {
+	db *sql.DB
+}
+
+func NewTimelineitemsRepository(db *sql.DB) repository.TimelineItemsRepository {
+	return &timelineitemsRepository{db}
+}
+
+func (r *timelineitemsRepository) SpecificUserPosts(userID string) ([]*entity.TimelineItem, error) {
+	query := `SELECT * FROM timelineitems WHERE author_id = $1`
+
+	rows, err := r.db.Query(query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var timelineitems []*entity.TimelineItem
+	for rows.Next() {
+		var (
+			id             uuid.UUID
+			postType       string
+			author_id      uuid.UUID
+			parent_post_id uuid.NullUUID
+			text           string
+			created_at     time.Time
+		)
+		if err := rows.Scan(&id, &postType, &author_id, &parent_post_id, &text, &created_at); err != nil {
+			return nil, err
+		}
+
+		timelineitem := entity.TimelineItem{
+			Type:         postType,
+			ID:           id,
+			AuthorID:     author_id,
+			ParentPostID: parent_post_id,
+			Text:         text,
+			CreatedAt:    created_at,
+		}
+		timelineitems = append(timelineitems, &timelineitem)
+	}
+
+	return timelineitems, nil
+}
+
+func (r *timelineitemsRepository) UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error) {
+	query := `
+		SELECT timelineitems.* 
+		FROM timelineitems
+		LEFT JOIN followships ON timelineitems.author_id = followships.target_user_id
+		WHERE followships.source_user_id = $1
+		OR timelineitems.author_id = $1
+		ORDER BY timelineitems.created_at DESC
+	`
+	rows, err := r.db.Query(query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var timelineitems []*entity.TimelineItem
+	for rows.Next() {
+		var (
+			id             uuid.UUID
+			postType       string
+			author_id      uuid.UUID
+			parent_post_id uuid.NullUUID
+			text           string
+			created_at     time.Time
+		)
+		if err := rows.Scan(&id, &postType, &author_id, &parent_post_id, &text, &created_at); err != nil {
+			return nil, err
+		}
+
+		timelineitem := entity.TimelineItem{
+			Type:         postType,
+			ID:           id,
+			AuthorID:     author_id,
+			ParentPostID: parent_post_id,
+			Text:         text,
+			CreatedAt:    created_at,
+		}
+		timelineitems = append(timelineitems, &timelineitem)
+	}
+
+	return timelineitems, nil
+}

--- a/go/internal/lib/featureflag/timeline.go
+++ b/go/internal/lib/featureflag/timeline.go
@@ -10,7 +10,7 @@ type timelineFeatureFlag struct {
 }
 
 const (
-	useNewSchemaEnvKey = "USE_NEW_SCHEMA"
+	UseNewSchemaEnvKey = "USE_NEW_SCHEMA"
 )
 
 var (
@@ -21,15 +21,15 @@ var (
 func TimelineFeatureFlag() *timelineFeatureFlag {
 	once.Do(func() {
 		timelineFeatureFlagInstance = &timelineFeatureFlag{
-			UseNewSchema: booleanFlag(false, useNewSchemaEnvKey),
+			UseNewSchema: booleanFlag(false, UseNewSchemaEnvKey),
 		}
 	})
 	return timelineFeatureFlagInstance
 }
 
-// resetTimelineFeatureFlag resets the timeline feature flag singleton instance and the sync.Once.
+// ResetTimelineFeatureFlag resets the timeline feature flag singleton instance and the sync.Once.
 // This is primarily used for testing purposes to ensure a clean state between tests.
-func resetTimelineFeatureFlag() {
+func ResetTimelineFeatureFlag() {
 	once = sync.Once{}
 	timelineFeatureFlagInstance = nil
 }

--- a/go/internal/lib/featureflag/timeline_test.go
+++ b/go/internal/lib/featureflag/timeline_test.go
@@ -7,7 +7,7 @@ import (
 func TestTimelineFeatureFlag(t *testing.T) {
 	t.Run("Default value (false)", func(t *testing.T) {
 		t.Cleanup(func() {
-			resetTimelineFeatureFlag()
+			ResetTimelineFeatureFlag()
 		})
 		if TimelineFeatureFlag().UseNewSchema {
 			t.Error("Expected UseNewSchema to be false, but got true")
@@ -16,9 +16,9 @@ func TestTimelineFeatureFlag(t *testing.T) {
 
 	t.Run("Environment variable set to true", func(t *testing.T) {
 		t.Cleanup(func() {
-			resetTimelineFeatureFlag()
+			ResetTimelineFeatureFlag()
 		})
-		t.Setenv(useNewSchemaEnvKey, "true")
+		t.Setenv(UseNewSchemaEnvKey, "true")
 		if !TimelineFeatureFlag().UseNewSchema {
 			t.Error("Expected UseNewSchema to be true, but got false")
 		}
@@ -26,9 +26,9 @@ func TestTimelineFeatureFlag(t *testing.T) {
 
 	t.Run("Environment variable set to false", func(t *testing.T) {
 		t.Cleanup(func() {
-			resetTimelineFeatureFlag()
+			ResetTimelineFeatureFlag()
 		})
-		t.Setenv(useNewSchemaEnvKey, "false")
+		t.Setenv(UseNewSchemaEnvKey, "false")
 		if TimelineFeatureFlag().UseNewSchema {
 			t.Error("Expected UseNewSchema to be false, but got true")
 		}

--- a/openapi/components/responses/create_post_response.yml
+++ b/openapi/components/responses/create_post_response.yml
@@ -1,17 +1,42 @@
-type: object
 title: CreatePostResponse
-required:
-  - id
-  - user_id
-  - text
-  - created_at
-properties:
-  id:
-    type: string
-  user_id:
-    type: string
-  text:
-    type: string
-  created_at:
-    type: string
-    format: date-time
+oneOf:
+  - type: object
+    title: CreatePostResponsePosts
+    description: Response when creating a post (old schema).
+    required:
+      - id
+      - user_id
+      - text
+      - created_at
+    properties:
+      id:
+        type: string
+      user_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+
+  - type: object
+    title: CreatePostResponseTimelineItems
+    description: Response when creating a timeline item (new schema).
+    required:
+      - type
+      - id
+      - author_id
+      - text
+      - created_at
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+      author_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time

--- a/openapi/components/responses/create_quote_repost_response.yml
+++ b/openapi/components/responses/create_quote_repost_response.yml
@@ -1,20 +1,48 @@
-type: object
 title: CreateQuoteRepostResponse
-required:
-  - id
-  - parent_id
-  - user_id
-  - text
-  - created_at
-properties:
-  id:
-    type: string
-  parent_id:
-    type: string
-  user_id:
-    type: string
-  text:
-    type: string
-  created_at:
-    type: string
-    format: date-time
+oneOf:
+  - type: object
+    title: CreateQuoteRepostResponseReposts
+    description: Response when creating a quote repost (old schema).
+    required:
+      - id
+      - parent_id
+      - user_id
+      - text
+      - created_at
+    properties:
+      id:
+        type: string
+      parent_id:
+        type: string
+      user_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+
+  - type: object
+    title: CreateQuoteRepostResponseTimelineItems
+    description: Response when creating a quote repost (new schema).
+    required:
+      - type
+      - id
+      - author_id
+      - parent_post_id
+      - text
+      - created_at
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+      author_id:
+        type: string
+      parent_post_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time

--- a/openapi/components/responses/create_repost_response.yml
+++ b/openapi/components/responses/create_repost_response.yml
@@ -1,20 +1,48 @@
-type: object
 title: CreateRepostResponse
-required:
-  - id
-  - parent_id
-  - user_id
-  - text
-  - created_at
-properties:
-  id:
-    type: string
-  parent_id:
-    type: string
-  user_id:
-    type: string
-  text:
-    type: string
-  created_at:
-    type: string
-    format: date-time
+oneOf:
+  - type: object
+    title: CreateRepostResponseReposts
+    description: Response when creating a repost (old schema).
+    required:
+      - id
+      - parent_id
+      - user_id
+      - text
+      - created_at
+    properties:
+      id:
+        type: string
+      parent_id:
+        type: string
+      user_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+
+  - type: object
+    title: CreateRepostResponseTimelineItems
+    description: Response when creating a repost (new schema).
+    required:
+      - type
+      - id
+      - author_id
+      - parent_post_id
+      - text
+      - created_at
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+      author_id:
+        type: string
+      parent_post_id:
+        type: string
+      text:
+        type: string
+      created_at:
+        type: string
+        format: date-time

--- a/openapi/components/responses/get_user_posts_timeline_response.yml
+++ b/openapi/components/responses/get_user_posts_timeline_response.yml
@@ -1,28 +1,72 @@
-type: array
 title: GetUserPostsTimelineResponse
-items:
-  type: object
-  required:
-    - id
-    - user_id
-    - text
-    - created_at
-  properties:
-    id:
-      type: string
-    user_id:
-      type: string
-    text:
-      type: string
-    created_at:
-      type: string
-      format: date-time
-example:
-  - id: "b579c6df-4faf-418b-ba44-e7eab8860c6f"
-    user_id: "f019a863-923e-4155-bcd1-a964035d65d0"
-    text: "A sample post"
-    created_at: "2024-09-29T10:20:30Z"
-  - id: "d8f91b8b-208c-4fe6-b1a0-75ca01ece67c"
-    user_id: "f019a863-923e-4155-bcd1-a964035d65d0"
-    text: "A same user post"
-    created_at: "2024-09-29T11:20:30Z"
+oneOf:
+  - type: array
+    title: UserPostsResponse
+    description: Response when fetching user posts (old schema).
+    items:
+      type: object
+      required:
+        - id
+        - user_id
+        - text
+        - created_at
+      properties:
+        id:
+          type: string
+        user_id:
+          type: string
+        text:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    example:
+      - id: "b579c6df-4faf-418b-ba44-e7eab8860c6f"
+        user_id: "f019a863-923e-4155-bcd1-a964035d65d0"
+        text: "A sample post"
+        created_at: "2024-09-29T10:20:30Z"
+      - id: "d8f91b8b-208c-4fe6-b1a0-75ca01ece67c"
+        user_id: "f019a863-923e-4155-bcd1-a964035d65d0"
+        text: "A same user post"
+        created_at: "2024-09-29T11:20:30Z"
+
+  - type: array
+    title: TimelineItemsResponse
+    description: Response when fetching timeline items (new schema).
+    items:
+      type: object
+      required:
+        - type
+        - id
+        - author_id
+        - text
+        - created_at
+      properties:
+        type:
+          type: string
+          enum: [post, repost, quoteRepost]
+        id:
+          type: string
+        author_id:
+          type: string
+        parent_post_id:
+          type: string
+          nullable: true
+        text:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    example:
+      - type: "post"
+        id: "5b21ca67-64c5-488e-8bc7-739c1a43d41b"
+        author_id: "a1c1f2b5-4e9f-4fdd-9f3e-df1bb79c1b6d"
+        parent_post_id: null
+        text: "A timeline post"
+        created_at: "2024-09-29T12:30:00Z"
+      - type: "repost"
+        id: "a567fcb4-9d2e-4d48-9e36-b1e733e7eb0a"
+        author_id: "a1c1f2b5-4e9f-4fdd-9f3e-df1bb79c1b6d"
+        parent_post_id: "5b21ca67-64c5-488e-8bc7-739c1a43d41b"
+        text: ""
+        created_at: "2024-09-29T13:00:00Z"

--- a/openapi/paths/user_posts.yml
+++ b/openapi/paths/user_posts.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - X-Clone
-  summary: Get a collection of posts by the specified user.
+  summary: Get a collection of posts or timelineitems by the specified user.
   parameters:
     - in: path
       name: id
@@ -11,7 +11,7 @@ get:
   operationId: GetUserPostsTimeline
   responses:
     "200":
-      description: A collection of posts by the specified user.
+      description: A collection of posts or timelineitems by the specified user.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Issue Number
#572 

## Implementation Summary
Update the database schema to manage posts, reposts, and quote reposts in a single table. Implement handlers other than `get_reverse_chronological_home_timeline` to align with the schema changes. The `get_reverse_chronological_home_timeline` handler will be implemented later. Use a feature flag to separate the processing for the old and new schemas.

## Scope of Impact
- database schema
- `CreatePost`, `CreateRepost`, `CreateQuoteRepost`, `DeleteRepost`, `GetUserPostsTimeline`
 handlers and tests
- usecase related to GetUserPostsTimeline

## Particular points to check
Please check whether each handler is implemented to support the new schema.

## Test
`go test -v ./...`

## Schedule
03/22
