### PR TITLE
[Go] Fix the getReverseChronologicalHomeTimeline test

### DIFF
--- a/go/internal/controller/handler/get_reverse_chronological_home_timeline_test.go
+++ b/go/internal/controller/handler/get_reverse_chronological_home_timeline_test.go
@@ -92,9 +92,8 @@ func (s *handlerTestSuite) TestGetReverseChronologicalHomeTimeline() {
 		).WithContext(ctx)
 		req.SetPathValue("id", test.userID)
 
-		getReverseChronologicalHomeTimelineHandler := NewGetReverseChronologicalHomeTimelineHandler(s.db, &s.mu, &s.userChannels)
+		getReverseChronologicalHomeTimelineHandler := NewGetReverseChronologicalHomeTimelineHandler(s.db, &s.mu, &s.userChannels, s.connected)
 
-		// GetReverseChronologicalHomeTimeline(rr, req, s.getUserAndFolloweePostsUsecase, &s.mu, &s.userChannels)
 		var wg sync.WaitGroup
 
 		wg.Add(1)
@@ -104,6 +103,11 @@ func (s *handlerTestSuite) TestGetReverseChronologicalHomeTimeline() {
 		}()
 		var posts []entity.Post
 		var reposts []entity.Repost
+
+		// This channel indicates that the httptest client has successfully connected to the handler.
+		// Wait here to ensure that the connection is established before triggering timeline updates.
+		<-s.connected
+
 		if test.name == "get posts already posted and posts posted during timeline access" {
 			time.Sleep(100 * time.Millisecond)
 			_ = s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test5" }`, test.userID))

--- a/go/internal/controller/handler/setup_test.go
+++ b/go/internal/controller/handler/setup_test.go
@@ -88,6 +88,7 @@ type handlerTestSuite struct {
 	muteUserUsecase                usecase.MuteUserUsecase
 	userChannels                   map[string]chan value.TimelineEvent
 	mu                             sync.Mutex
+	connected                      chan struct{}
 }
 
 // SetupTest runs before each test in the suite.
@@ -141,6 +142,8 @@ func (s *handlerTestSuite) SetupTest() {
 
 	s.mu = sync.Mutex{}
 	s.userChannels = make(map[string]chan value.TimelineEvent)
+
+	s.connected = make(chan struct{})
 
 	m.Up()
 }

--- a/go/internal/controller/server.go
+++ b/go/internal/controller/server.go
@@ -35,6 +35,6 @@ func NewServer(db *sql.DB, mu *sync.Mutex, usersChan *map[string]chan value.Time
 		CreateQuoteRepostHandler:                   handler.NewCreateQuoteRepostHandler(db, mu, usersChan),
 		DeleteRepostHandler:                        handler.NewDeleteRepostHandler(db, mu, usersChan),
 		GetUserPostsTimelineHandler:                handler.NewGetUserPostsTimelineHandler(db),
-		GetReverseChronologicalHomeTimelineHandler: handler.NewGetReverseChronologicalHomeTimelineHandler(db, mu, usersChan),
+		GetReverseChronologicalHomeTimelineHandler: handler.NewGetReverseChronologicalHomeTimelineHandler(db, mu, usersChan, make(chan struct{}, 1)),
 	}
 }


### PR DESCRIPTION
## Issue Number
#619 

## Implementation Summary
Last Saturday, we discussed eliminating the environmental dependency by creating a new posting event when the event type is `InitialAccess`, but it did not work for the following reasons.
`httptest.NewRecorder()` writes the result received at the end of the handler's execution. `scanner.Scan()` requires the handler's function execution to have finished reading the response, and therefore, even if `the timelineEvent.EventType` causes a new post or other action, it will not be added to the recorder.
I added a channel to GetReverseChronologicalHomeTimelineHandler to tell it it is connected and to wait for this connection result when testing.

## Scope of Impact
- `getReverseChronologicalHomeTimelineHandler` has a new member, named connected, which is used to tell the connection between client and server is established.
- in `TestGetReverseChronologicalHomeTimeline`, use the connected channel to confirm the test client access to the `getReverseChronologicalHomeTimelineHandler` instead of `time.sleep()` to avoid environmental dependency

## Particular points to check
Please check if there are any environmental dependencies remaining in the test.



## Test
`go test ./...`

## Schedule
03/21
