### PR TITLE
[TS] Fix the flaky test for PostModal

### DIFF
--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.tsx
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.tsx
@@ -38,11 +38,12 @@ export const PostModal: React.FC<PostModalProps> = ({ isIntercepted }) => {
   // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/525
   // - Replace useFormState with useActionState after upgrading React to v19.
   const [message, formAction] = useFormState(handlePostButtonClick, undefined);
-  const initialRef = useRef(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  if (textAreaRef.current) textAreaRef.current.focus();
 
   return (
     <Modal
-      initialFocusRef={initialRef}
+      initialFocusRef={textAreaRef}
       isOpen={true}
       onClose={handleCloseButtonClick}
       size="xl"
@@ -74,7 +75,7 @@ export const PostModal: React.FC<PostModalProps> = ({ isIntercepted }) => {
               <Textarea
                 data-testid="text"
                 name="text"
-                ref={initialRef}
+                ref={textAreaRef}
                 value={postText}
                 onChange={handleTextAreaChange}
                 placeholder="What is happening?!"


### PR DESCRIPTION
## Issue Number
#622 

## Implementation Summary
When Chromatic captures a screenshot of the "Error Form" test for "PostModal", the bottom-left icon sometimes receives focus (as seen in the right image). This caused the VRT to be flaky.

I fixed this issue by ensuring the text area gains focus not only when the modal is first opened but also after a submission failure.
![スクリーンショット 2025-03-20 21 48 52](https://github.com/user-attachments/assets/5f4b027c-6c12-4b26-b45a-e4c7017903dd)

## Scope of Impact
- PostModal

## Particular points to check
Please verify that the text area gains focus after a submission failure.  
You can check it [[here](http://localhost:6006/?path=/story/features-postmodal--error-form)](http://localhost:6006/?path=/story/features-postmodal--error-form) after running `yarn storybook`.


## Test
Chromatic automatically runs VRT.

## Schedule
3/28
