### PR TITLE
[Go] Implement CreateUser method for fake UsersRepository

### DIFF
--- a/go/internal/application/usecase/errors.go
+++ b/go/internal/application/usecase/errors.go
@@ -1,0 +1,7 @@
+package usecase
+
+import "errors"
+
+var (
+	ErrUserAlreadyExists = errors.New("user already exists")
+)

--- a/go/internal/application/usecase/interactor/create_user.go
+++ b/go/internal/application/usecase/interactor/create_user.go
@@ -1,6 +1,8 @@
 package interactor
 
 import (
+	"errors"
+
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/repository"
@@ -14,10 +16,13 @@ func NewCreateUserUsecase(usersRepository repository.UsersRepository) usecase.Cr
 	return &createUserUsecase{usersRepository: usersRepository}
 }
 
-func (p *createUserUsecase) CreateUser(username, displayName, hashedPassword string) (entity.User, error) {
+func (u *createUserUsecase) CreateUser(username, displayName, hashedPassword string) (entity.User, error) {
 	var user entity.User
-	user, err := p.usersRepository.CreateUser(nil, username, displayName, hashedPassword)
+	user, err := u.usersRepository.CreateUser(nil, username, displayName, hashedPassword)
 	if err != nil {
+		if errors.Is(err, repository.ErrUniqueViolation) {
+			return entity.User{}, usecase.ErrUserAlreadyExists
+		}
 		return entity.User{}, err
 	}
 

--- a/go/internal/controller/handler/create_user.go
+++ b/go/internal/controller/handler/create_user.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -56,7 +57,7 @@ func (h *CreateUserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var code int
 
-		if persistence.IsUniqueViolationError(err) {
+		if errors.Is(err, usecase.ErrUserAlreadyExists) {
 			code = http.StatusConflict
 		} else {
 			code = http.StatusInternalServerError

--- a/go/internal/domain/repository/errors.go
+++ b/go/internal/domain/repository/errors.go
@@ -1,0 +1,7 @@
+package repository
+
+import "errors"
+
+var (
+	ErrUniqueViolation = errors.New("unique violation")
+)

--- a/go/internal/domain/repository/users.go
+++ b/go/internal/domain/repository/users.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+
 	"x-clone-backend/internal/domain/entity"
 
 	"github.com/google/uuid"
@@ -22,4 +23,6 @@ type UsersRepository interface {
 	UnmuteUser(tx *sql.Tx, sourceUserID, targetUserID string) error
 	BlockUser(tx *sql.Tx, sourceUserID, targetUserID string) error
 	UnblockUser(tx *sql.Tx, sourceUserID, targetUserID string) error
+
+	SetCreateUserError(err error)
 }

--- a/go/internal/infrastructure/fake/users.go
+++ b/go/internal/infrastructure/fake/users.go
@@ -1,0 +1,114 @@
+package fake
+
+import (
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+)
+
+type fakeUsersRepository struct {
+	mu              sync.RWMutex
+	users           map[uuid.UUID]entity.User
+	createUserError error
+}
+
+func NewFakeUsersRepository() repository.UsersRepository {
+	return &fakeUsersRepository{
+		mu:              sync.RWMutex{},
+		users:           make(map[uuid.UUID]entity.User),
+		createUserError: nil,
+	}
+}
+
+// SetCreateUserError sets the error that will be returned by CreateUser.
+func (r *fakeUsersRepository) SetCreateUserError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.createUserError = err
+}
+
+func (r *fakeUsersRepository) WithTransaction(fn func(tx *sql.Tx) error) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) CreateUser(tx *sql.Tx, username, displayName, password string) (entity.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.createUserError != nil {
+		return entity.User{}, r.createUserError
+	}
+
+	user := entity.User{
+		ID:          uuid.New(),
+		Username:    username,
+		DisplayName: displayName,
+		Password:    password,
+		Bio:         "",
+		IsPrivate:   false,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	for _, u := range r.users {
+		if u.Username == user.Username {
+			return entity.User{}, repository.ErrUniqueViolation
+		}
+	}
+	r.users[user.ID] = user
+
+	return user, nil
+}
+
+func (r *fakeUsersRepository) DeleteUser(tx *sql.Tx, userID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) GetSpecificUser(tx *sql.Tx, userID string) (entity.User, error) {
+	return entity.User{}, nil
+}
+
+func (r *fakeUsersRepository) GetUserByUsername(tx *sql.Tx, username string) (entity.User, error) {
+	return entity.User{}, nil
+}
+
+func (r *fakeUsersRepository) UserByUsername(tx *sql.Tx, username string) (entity.User, error) {
+	return entity.User{}, nil
+}
+
+func (r *fakeUsersRepository) LikePost(tx *sql.Tx, userID string, postID uuid.UUID) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) UnlikePost(tx *sql.Tx, userID string, postID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) FollowUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) UnfollowUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) MuteUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) UnmuteUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) BlockUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}
+
+func (r *fakeUsersRepository) UnblockUser(tx *sql.Tx, sourceUserID, targetUserID string) error {
+	return nil
+}

--- a/go/internal/infrastructure/fake/users_test.go
+++ b/go/internal/infrastructure/fake/users_test.go
@@ -1,0 +1,61 @@
+package fake
+
+import (
+	"errors"
+	"testing"
+
+	"x-clone-backend/internal/domain/repository"
+
+	"github.com/google/uuid"
+)
+
+func TestFakeUsersRepository_CreateUser(t *testing.T) {
+	fakeUsersRepository := NewFakeUsersRepository()
+
+	username, displayName, password := "test_user", "test user", "password"
+
+	user, err := fakeUsersRepository.CreateUser(nil, username, displayName, password)
+	if err != nil {
+		t.Errorf("Error creating user: %v", err)
+	}
+
+	if user.ID == uuid.Nil {
+		t.Errorf("Expected non-nil user ID, got nil")
+	}
+	if user.Username != username {
+		t.Errorf("Expected username %s, got %s", username, user.Username)
+	}
+	if user.DisplayName != displayName {
+		t.Errorf("Expected display name %s, got %s", displayName, user.DisplayName)
+	}
+	if user.Password != password {
+		t.Errorf("Expected password %s, got %s", password, user.Password)
+	}
+	if user.Bio != "" {
+		t.Errorf("Expected empty bio, got %s", user.Bio)
+	}
+	if user.IsPrivate != false {
+		t.Errorf("Expected IsPrivate to be false, got true")
+	}
+
+	// Create a user with the same username (unique violation).
+	_, err = fakeUsersRepository.CreateUser(nil, "test_user", "test user", "password")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if !errors.Is(err, repository.ErrUniqueViolation) {
+		t.Errorf("Expected unique violation error, got %v", err)
+	}
+}
+
+func TestFakeUsersRepository_CreateUser_WithError(t *testing.T) {
+	fakeUsersRepository := NewFakeUsersRepository()
+
+	expectedErr := errors.New("something went wrong")
+	fakeUsersRepository.SetCreateUserError(expectedErr)
+
+	_, err := fakeUsersRepository.CreateUser(nil, "test_user", "test user", "password")
+	if err != expectedErr {
+		t.Errorf("Expected error %v, got %v", expectedErr, err)
+	}
+}

--- a/go/internal/infrastructure/persistence/users.go
+++ b/go/internal/infrastructure/persistence/users.go
@@ -58,6 +58,10 @@ func (r *usersRepository) CreateUser(tx *sql.Tx, username, displayName, password
 		err = r.db.QueryRow(query, username, displayName, password, "", false).Scan(&id, &createdAt, &updatedAt)
 	}
 	if err != nil {
+		if IsUniqueViolationError(err) {
+			return entity.User{}, repository.ErrUniqueViolation
+		}
+
 		return entity.User{}, err
 	}
 
@@ -285,3 +289,5 @@ func (r *usersRepository) UnblockUser(tx *sql.Tx, sourceUserID, targetUserID str
 
 	return nil
 }
+
+func (r *usersRepository) SetCreateUserError(err error) {}


### PR DESCRIPTION
## Issue Number
#629 

## Implementation Summary
This PR introduces `fakeUsersRepository`, a fake implementation of `UsersRepository`, and implements the `CreateUser` method for it. Instead of using a real database, it stores records in a map to simulate the behavior of the actual implementation.  
To allow controlled behavior, it includes a `createUserError` field, enabling callers to set an error that `CreateUser` will return.  
Since `fakeUsersRepository` has not yet been fully implemented, `NewUsersRepository` currently always returns the real implementation. The remaining functionality will be implemented in a future task.

## Scope of Impact
- `fakeUsersRepository` is used in the test environment to mimic the real implementation.

## Particular points to check
Please check if the fake implementation and the way to control behavior are appropriate.

## Test
- `infrastructure/fake/users_test.go` tests the `fakeUsersRepository`.

## Schedule
3/28
