### PR TITLE
[TS] Implement a Sign Up Modal Screen

### DIFF
--- a/ts/twitter/package.json
+++ b/ts/twitter/package.json
@@ -14,8 +14,11 @@
     "chromatic": "chromatic"
   },
   "imports": {
+    "#src/lib/actions/mocks/*": {
+      "default": "./src/lib/actions/mocks/*.ts"
+    },
     "#src/lib/actions/*": {
-      "storybook": "./src/lib/actions/*.mock.ts",
+      "storybook": "./src/lib/actions/mocks/*.mock.ts",
       "default": "./src/lib/actions/*.ts"
     }
   },

--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.stories.ts
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/post-modal.stories.ts
@@ -1,8 +1,8 @@
-import { createPost } from "@/lib/actions/create-post.mock";
 import { err, ok } from "@/lib/actions/types";
 import { ERROR_MESSAGES, STATUS_TEXT } from "@/lib/constants/error-messages";
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, screen, userEvent, within } from "@storybook/test";
+import { createPost } from "#src/lib/actions/mocks/create-post.mock";
 import { PostModal } from "./post-modal";
 
 const meta: Meta<typeof PostModal> = {

--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
@@ -1,8 +1,8 @@
-import { createPost } from "@/lib/actions/create-post";
 import { ERROR_MESSAGES } from "@/lib/constants/error-messages";
 import type { User } from "@/lib/models/user";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { createPost } from "#src/lib/actions/create-post";
 
 interface UsePostModalProps {
   isIntercepted: boolean;

--- a/ts/twitter/src/app/login/_components/login-modal.tsx
+++ b/ts/twitter/src/app/login/_components/login-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { LoginFormValue } from "@/lib/models/login-form-types";
+import type { LoginBody } from "@/lib/actions/login";
 import { Box, Flex } from "@chakra-ui/react";
 import { useState } from "react";
 import type React from "react";
@@ -9,7 +9,7 @@ import { PasswordModal } from "./password-modal";
 
 export const LoginModal: React.FC = () => {
   const [showPasswordModal, setShowPasswordModal] = useState(false);
-  const [loginFormValue, setLoginFormValue] = useState<LoginFormValue>({
+  const [loginFormValue, setLoginFormValue] = useState<LoginBody>({
     username: "",
     password: "",
   });

--- a/ts/twitter/src/app/login/_components/password-modal.tsx
+++ b/ts/twitter/src/app/login/_components/password-modal.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import type { LoginFormValue } from "@/lib/models/login-form-types";
+import type { LoginBody } from "@/lib/actions/login";
 import { Box, Button, Input, Text, VStack } from "@chakra-ui/react";
 import { useFormState } from "react-dom";
 import { FaArrowLeft } from "react-icons/fa";
 import { usePasswordModal } from "./use-password-modal";
 
 interface PasswordModalProps {
-  loginFormValue: LoginFormValue;
+  loginFormValue: LoginBody;
   handleBackButtonClick: () => void;
   handlePasswordChange: (password: string) => void;
 }

--- a/ts/twitter/src/app/signup/_components/signup-modal.stories.tsx
+++ b/ts/twitter/src/app/signup/_components/signup-modal.stories.tsx
@@ -1,0 +1,64 @@
+import { err, ok } from "@/lib/actions/types";
+import { ERROR_MESSAGES, STATUS_TEXT } from "@/lib/constants/error-messages";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, screen, userEvent, within } from "@storybook/test";
+import { signup } from "#src/lib/actions/mocks/signup.mock";
+import { SignupModal } from "./signup-modal";
+
+const meta: Meta<typeof SignupModal> = {
+  title: "Features/SignupModal",
+  component: SignupModal,
+  tags: ["!autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SignupModal>;
+
+export const Primary: Story = {
+  async beforeEach() {
+    signup.mockImplementation(async () => {
+      return ok({
+        token: "mock-token-123",
+        user: {
+          id: "user-123",
+          username: "testuser",
+          displayName: "Test User",
+          bio: "",
+          isPrivate: false,
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      });
+    });
+  },
+};
+
+export const ErrorForm: Story = {
+  async beforeEach() {
+    signup.mockImplementation(async () => {
+      return err({
+        status: 500,
+        statusText: STATUS_TEXT.INTERNAL_SERVER_ERROR,
+      });
+    });
+  },
+  play: async () => {
+    const canvas = within(screen.getByRole("dialog"));
+
+    await userEvent.type(
+      canvas.getByPlaceholderText("Display name"),
+      "Test User",
+    );
+
+    await userEvent.type(
+      canvas.getByPlaceholderText("Password"),
+      "securepassword",
+    );
+
+    await userEvent.click(canvas.getByText("Register"));
+
+    await expect(
+      canvas.findByText(new RegExp(ERROR_MESSAGES.SIGNUP_ERROR)),
+    ).resolves.toBeInTheDocument();
+  },
+};

--- a/ts/twitter/src/app/signup/_components/signup-modal.tsx
+++ b/ts/twitter/src/app/signup/_components/signup-modal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { VALIDATION_CONSTANTS } from "@/lib/constants/validation-constants";
+import {
+  Box,
+  Button,
+  Dialog,
+  Flex,
+  Input,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import type React from "react";
+import { useFormState } from "react-dom";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { RxCross2 } from "react-icons/rx";
+import { useSignupModal } from "./use-signup-modal";
+
+export const SignupModal: React.FC = () => {
+  const {
+    formValues,
+    showPassword,
+    handleInputChange,
+    togglePasswordVisibility,
+    handleSignupAction,
+    isSubmitDisabled,
+    handleCloseButtonClick,
+  } = useSignupModal();
+  const [message, formAction] = useFormState(handleSignupAction, undefined);
+
+  return (
+    <Dialog.Root open={true}>
+      <Dialog.Backdrop />
+      <Dialog.Content
+        bg="surface.dark"
+        color="white"
+        borderRadius="md"
+        boxShadow="md"
+        border="1px solid"
+        borderColor="gray"
+        width="400px"
+        position="fixed"
+        top="50%"
+        left="50%"
+        transform="translate(-50%, -50%)"
+      >
+        <Dialog.CloseTrigger
+          position="absolute"
+          top="3"
+          left="3"
+          onClick={handleCloseButtonClick}
+          color="gray"
+        >
+          <RxCross2 size={18} />
+        </Dialog.CloseTrigger>
+
+        <Dialog.Body p="6">
+          <form action={formAction}>
+            <Stack gap={4}>
+              <Flex direction="column" align="center" mb="4">
+                <Text
+                  fontSize="xl"
+                  fontWeight="bold"
+                  mb="1"
+                  color="blue.primary"
+                >
+                  Create an account
+                </Text>
+              </Flex>
+
+              {message !== undefined && (
+                <Box
+                  bg="error.primary"
+                  borderRadius="sm"
+                  borderLeft="3px solid"
+                  borderColor="red"
+                  p={3}
+                >
+                  <Text color="white">{message}</Text>
+                </Box>
+              )}
+
+              <Box>
+                <Text fontWeight="medium" mb="1">
+                  Display Name
+                </Text>
+                <Input
+                  value={formValues.displayName}
+                  onChange={(e) =>
+                    handleInputChange("displayName", e.target.value)
+                  }
+                  placeholder="Display name"
+                  _placeholder={{ color: "gray" }}
+                  name="displayName"
+                  bg="black"
+                  borderColor="gray"
+                />
+              </Box>
+
+              <Box>
+                <Text fontWeight="medium" mb="1">
+                  Username
+                </Text>
+                <Flex>
+                  <Flex
+                    align="center"
+                    justify="center"
+                    bg="black"
+                    px="3"
+                    borderWidth="1px"
+                    borderColor="gray"
+                    borderRightWidth="0"
+                    borderLeftRadius="md"
+                  >
+                    @
+                  </Flex>
+                  <Input
+                    value={formValues.username}
+                    onChange={(e) =>
+                      handleInputChange("username", e.target.value)
+                    }
+                    placeholder="username"
+                    _placeholder={{ color: "gray" }}
+                    name="username"
+                    maxLength={VALIDATION_CONSTANTS.USERNAME.MAX_LENGTH}
+                    bg="black"
+                    borderColor="gray"
+                    borderLeftRadius="0"
+                  />
+                </Flex>
+                <Text fontSize="xs" color="gray" mt="1">
+                  {`Username must be between ${VALIDATION_CONSTANTS.USERNAME.MIN_LENGTH} and ${VALIDATION_CONSTANTS.USERNAME.MAX_LENGTH} characters.`}
+                </Text>
+              </Box>
+
+              <Box>
+                <Text fontWeight="medium" mb="1">
+                  Password
+                </Text>
+                <Flex position="relative">
+                  <Input
+                    type={showPassword ? "text" : "password"}
+                    value={formValues.password}
+                    onChange={(e) =>
+                      handleInputChange("password", e.target.value)
+                    }
+                    placeholder="Password"
+                    _placeholder={{ color: "gray" }}
+                    name="password"
+                    maxLength={VALIDATION_CONSTANTS.PASSWORD.MAX_LENGTH}
+                    bg="black"
+                    borderColor="gray"
+                    pr="10"
+                  />
+                  <Button
+                    variant="ghost"
+                    onClick={togglePasswordVisibility}
+                    title={showPassword ? "Hide password" : "Show password"}
+                    position="absolute"
+                    right="0"
+                    top="0"
+                    h="100%"
+                    color="gray"
+                  >
+                    {showPassword ? (
+                      <FaEyeSlash size={16} />
+                    ) : (
+                      <FaEye size={16} />
+                    )}
+                  </Button>
+                </Flex>
+                <Text fontSize="xs" color="gray" mt="1">
+                  {`Password must be between ${VALIDATION_CONSTANTS.PASSWORD.MIN_LENGTH} and ${VALIDATION_CONSTANTS.PASSWORD.MAX_LENGTH} characters.`}
+                </Text>
+              </Box>
+
+              <Button
+                type="submit"
+                bg="white"
+                color="black"
+                borderRadius="md"
+                fontWeight="medium"
+                mt="2"
+                disabled={isSubmitDisabled}
+                _hover={{
+                  bg: "blue.primaryHover",
+                }}
+              >
+                Register
+              </Button>
+            </Stack>
+          </form>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};

--- a/ts/twitter/src/app/signup/_components/use-signup-modal.ts
+++ b/ts/twitter/src/app/signup/_components/use-signup-modal.ts
@@ -1,0 +1,107 @@
+import { useAuth } from "@/lib/components/auth-context";
+import { ERROR_MESSAGES } from "@/lib/constants/error-messages";
+import { VALIDATION_CONSTANTS } from "@/lib/constants/validation-constants";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { type SignupBody, signup } from "#src/lib/actions/signup";
+
+interface UseSignupModalReturn {
+  formValues: SignupBody;
+  showPassword: boolean;
+  handleInputChange: (field: keyof SignupBody, value: string) => void;
+  togglePasswordVisibility: () => void;
+  handleSignupAction: (
+    prevState: string | undefined,
+    formData: FormData,
+  ) => Promise<string | undefined>;
+  isSubmitDisabled: boolean;
+  handleCloseButtonClick: () => void;
+}
+
+export const useSignupModal = (): UseSignupModalReturn => {
+  const [formValues, setFormValues] = useState<SignupBody>({
+    displayName: "",
+    username: "",
+    password: "",
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const router = useRouter();
+  const { setUser } = useAuth();
+
+  const generateUsername = (displayName: string): string => {
+    if (!displayName) return "";
+    return displayName
+      .toLowerCase()
+      .replace(/[^\w]/gi, "")
+      .substring(0, VALIDATION_CONSTANTS.USERNAME.MAX_LENGTH);
+  };
+
+  const handleInputChange = (field: keyof SignupBody, value: string) => {
+    const updatedForm = {
+      ...formValues,
+      [field]: value,
+    };
+
+    if (field === "displayName") {
+      updatedForm.username = generateUsername(value);
+    }
+
+    setFormValues(updatedForm);
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword((prev) => !prev);
+  };
+
+  const handleSignupAction = async (
+    prevState: string | undefined,
+    formData: FormData,
+  ) => {
+    try {
+      const displayName = formData.get("displayName") as string;
+      const username = formData.get("username") as string;
+      const password = formData.get("password") as string;
+
+      const result = await signup({ displayName, username, password });
+
+      if (!result.ok) {
+        return `${ERROR_MESSAGES.SIGNUP_ERROR} (${result.error.statusText})`;
+      }
+      setUser(result.value.user);
+
+      router.push("/home");
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        return ERROR_MESSAGES.CONNECTION_ERROR;
+      }
+      return ERROR_MESSAGES.UNKNOWN_ERROR;
+    }
+  };
+
+  const handleCloseButtonClick = () => {
+    router.back();
+  };
+
+  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/647
+  // - Use a validation library to validate the form data.
+  const isUsernameValid =
+    formValues.username.length >= VALIDATION_CONSTANTS.USERNAME.MIN_LENGTH &&
+    formValues.username.length <= VALIDATION_CONSTANTS.USERNAME.MAX_LENGTH;
+
+  const isPasswordValid =
+    formValues.password.length >= VALIDATION_CONSTANTS.PASSWORD.MIN_LENGTH &&
+    formValues.password.length <= VALIDATION_CONSTANTS.PASSWORD.MAX_LENGTH;
+
+  const isSubmitDisabled =
+    !formValues.displayName || !isUsernameValid || !isPasswordValid;
+
+  return {
+    formValues,
+    showPassword,
+    handleInputChange,
+    togglePasswordVisibility,
+    handleSignupAction,
+    isSubmitDisabled,
+    handleCloseButtonClick,
+  };
+};

--- a/ts/twitter/src/app/signup/page.tsx
+++ b/ts/twitter/src/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import { SignupModal } from "./_components/signup-modal";
+
+export default function Page() {
+  return <SignupModal />;
+}

--- a/ts/twitter/src/lib/actions/mocks/create-post.mock.ts
+++ b/ts/twitter/src/lib/actions/mocks/create-post.mock.ts
@@ -1,5 +1,5 @@
 import { fn } from "@storybook/test";
-import * as actual from "./create-post";
+import * as actual from "../create-post";
 
-export * from "./create-post";
+export * from "../create-post";
 export const createPost = fn(actual.createPost).mockName("createPost");

--- a/ts/twitter/src/lib/actions/mocks/signup.mock.ts
+++ b/ts/twitter/src/lib/actions/mocks/signup.mock.ts
@@ -1,0 +1,5 @@
+import { fn } from "@storybook/test";
+import * as actual from "../signup";
+
+export * from "../signup";
+export const signup = fn(actual.signup).mockName("signup");

--- a/ts/twitter/src/lib/actions/signup.ts
+++ b/ts/twitter/src/lib/actions/signup.ts
@@ -8,27 +8,32 @@ import {
   ok,
 } from "./types";
 
-export interface LoginBody {
+export interface SignupBody {
+  displayName: string;
   username: string;
   password: string;
 }
 
-interface LoginResponse {
+interface SignupResponse {
   token: string;
   user: User;
 }
 
-export async function login(
-  body: LoginBody,
-): Promise<ServerActionsResult<LoginResponse, ServerActionsError>> {
+export async function signup(
+  body: SignupBody,
+): Promise<ServerActionsResult<SignupResponse, ServerActionsError>> {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/login`,
+    `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/users`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        display_name: body.displayName,
+        username: body.username,
+        password: body.password,
+      }),
     },
   );
 
@@ -38,6 +43,8 @@ export async function login(
     const apiData = await res.json();
     const { user: apiUser, token } = apiData;
 
+    // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/648
+    // - Switch the login and signup response fields to camel case.
     const user: User = {
       id: apiUser.id,
       username: apiUser.username,

--- a/ts/twitter/src/lib/constants/error-messages.ts
+++ b/ts/twitter/src/lib/constants/error-messages.ts
@@ -4,6 +4,8 @@ export const ERROR_MESSAGES = {
   CONNECTION_ERROR: "Connection error occurred.",
   POST_CREATION_ERROR:
     "Something went wrong, but don't fret - let's give it another shot.",
+  SIGNUP_ERROR: "Something went wrong with signup. Please try again.",
+  UNKNOWN_ERROR: "An unknown error occurred.",
 } as const;
 
 export const STATUS_TEXT = {

--- a/ts/twitter/src/lib/constants/validation-constants.ts
+++ b/ts/twitter/src/lib/constants/validation-constants.ts
@@ -1,0 +1,12 @@
+export const VALIDATION_CONSTANTS = {
+  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/652
+  // - Update CreateUserRequest schema to match users table username constraints.
+  USERNAME: {
+    MIN_LENGTH: 4,
+    MAX_LENGTH: 14,
+  },
+  PASSWORD: {
+    MIN_LENGTH: 8,
+    MAX_LENGTH: 15,
+  },
+};

--- a/ts/twitter/src/lib/models/login-form-types.ts
+++ b/ts/twitter/src/lib/models/login-form-types.ts
@@ -1,4 +1,0 @@
-export interface LoginFormValue {
-  username: string;
-  password: string;
-}


### PR DESCRIPTION
## Issue Number
#638 

## Implementation Summary
Implement a signup modal screen for auth task.

## Scope of Impact
You can view a signup modal with signup path, and you can create user with this modal.

## Particular points to check
Check if the signup directory structure is correct.
Please confirm that the behaviors matches the video below when accessing http://localhost:3000/signup.

https://github.com/user-attachments/assets/810e6c22-c01e-41e2-9a9b-d39b6047edf1

## Schedule
4/5
