### PR TITLE
[Go] Implement fake timelineitems repository

### DIFF
--- a/go/internal/domain/repository/errors.go
+++ b/go/internal/domain/repository/errors.go
@@ -2,7 +2,20 @@ package repository
 
 import "errors"
 
+// These constants are used as keys in the `errors` map
+// of the fake repository to simulate operation-specific errors during testing.
+const (
+	ErrKeySpecificUserPosts    = "SpecificUserPosts"
+	ErrKeyUserAndFolloweePosts = "UserAndFolloweePosts"
+	ErrKeyCreatePost           = "CreatePost"
+	ErrKeyDeletePost           = "DeletePost"
+	ErrKeyCreateRepost         = "CreateRepost"
+	ErrKeyDeleteRepost         = "DeleteRepost"
+	ErrKeyCreateQuoteRepost    = "CreateQuoteRepost"
+)
+
 var (
 	ErrRecordNotFound  = errors.New("record not found")
 	ErrUniqueViolation = errors.New("unique violation")
+	ErrRepostViolation = errors.New("repost violation")
 )

--- a/go/internal/domain/repository/timelineitems.go
+++ b/go/internal/domain/repository/timelineitems.go
@@ -7,4 +7,13 @@ import (
 type TimelineItemsRepository interface {
 	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
 	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
+	CreatePost(userID, text string) (entity.TimelineItem, error)
+	DeletePost(postID string) error
+	CreateRepost(userID, postID string) (entity.TimelineItem, error)
+	DeleteRepost(postID string) error
+	CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error)
+
+	// These methods are used to set or clear simulated operation-specific errors in tests.
+	SetError(key string, err error)
+	ClearError(key string)
 }

--- a/go/internal/infrastructure/fake/timelineitems.go
+++ b/go/internal/infrastructure/fake/timelineitems.go
@@ -1,0 +1,235 @@
+package fake
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+	"x-clone-backend/internal/domain/value"
+)
+
+type fakeTimelineitemsRepository struct {
+	mu            sync.RWMutex
+	timelineItems map[string]*entity.TimelineItem
+
+	errors map[string]error
+}
+
+func NewFakeTimelineItemsRepository() repository.TimelineItemsRepository {
+	return &fakeTimelineitemsRepository{
+		mu:            sync.RWMutex{},
+		timelineItems: make(map[string]*entity.TimelineItem),
+
+		errors: make(map[string]error),
+	}
+}
+
+func (r *fakeTimelineitemsRepository) SpecificUserPosts(userID string) ([]*entity.TimelineItem, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if err, ok := r.errors[repository.ErrKeySpecificUserPosts]; ok {
+		return []*entity.TimelineItem{}, err
+	}
+
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return []*entity.TimelineItem{}, err
+	}
+
+	timelineItems := []*entity.TimelineItem{}
+
+	for _, item := range r.timelineItems {
+		if item.AuthorID == userUUID {
+			timelineItems = append(timelineItems, item)
+		}
+	}
+
+	return timelineItems, nil
+}
+
+// UserAndFolloweePosts returns all timeline items without filtering by followee.
+// This is a limitation of the fake repository used for testing,
+// as it does not have access to follow relationships, which are managed by the users repository.
+//
+// In a real implementation, this method would return posts by the given user　and their followees,
+// but here we simply return all timeline items to simulate behavior.
+func (r *fakeTimelineitemsRepository) UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if err, ok := r.errors[repository.ErrKeyUserAndFolloweePosts]; ok {
+		return []*entity.TimelineItem{}, err
+	}
+
+	var timelineItems []*entity.TimelineItem
+	for _, item := range r.timelineItems {
+		timelineItems = append(timelineItems, item)
+	}
+
+	return timelineItems, nil
+}
+
+func (r *fakeTimelineitemsRepository) CreatePost(userID, text string) (entity.TimelineItem, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err, ok := r.errors[repository.ErrKeyCreatePost]; ok {
+		return entity.TimelineItem{}, err
+	}
+
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return entity.TimelineItem{}, err
+	}
+	postID := uuid.New()
+	timelineItem := entity.TimelineItem{
+		Type:      entity.PostTypePost,
+		ID:        postID,
+		AuthorID:  userUUID,
+		Text:      text,
+		CreatedAt: time.Now(),
+	}
+	r.timelineItems[postID.String()] = &timelineItem
+
+	return timelineItem, nil
+}
+
+func (r *fakeTimelineitemsRepository) DeletePost(postID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err, ok := r.errors[repository.ErrKeyDeletePost]; ok {
+		return err
+	}
+
+	if _, ok := r.timelineItems[postID]; !ok {
+		return repository.ErrRecordNotFound
+	}
+
+	delete(r.timelineItems, postID)
+
+	return nil
+}
+
+func (r *fakeTimelineitemsRepository) CreateRepost(userID, postID string) (entity.TimelineItem, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err, ok := r.errors[repository.ErrKeyCreateRepost]; ok {
+		return entity.TimelineItem{}, err
+	}
+
+	if _, ok := r.timelineItems[postID]; !ok {
+		return entity.TimelineItem{}, repository.ErrRecordNotFound
+	}
+
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return entity.TimelineItem{}, err
+	}
+	postUUID, err := uuid.Parse(postID)
+	if err != nil {
+		return entity.TimelineItem{}, err
+	}
+	postNullUUID := value.NullUUID{UUID: postUUID, Valid: true}
+
+	parentPost := *r.timelineItems[postID]
+	if parentPost.Type == entity.PostTypeRepost {
+		return entity.TimelineItem{}, repository.ErrRepostViolation
+	}
+
+	if isRepostUniqueViolation(parentPost, postUUID, postNullUUID) {
+		return entity.TimelineItem{}, repository.ErrUniqueViolation
+	}
+
+	repostID := uuid.New()
+	timelineItem := entity.TimelineItem{
+		Type:         entity.PostTypeRepost,
+		ID:           repostID,
+		AuthorID:     userUUID,
+		ParentPostID: postNullUUID,
+		Text:         "",
+		CreatedAt:    time.Now(),
+	}
+
+	r.timelineItems[repostID.String()] = &timelineItem
+
+	return timelineItem, nil
+}
+
+func (r *fakeTimelineitemsRepository) DeleteRepost(postID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err, ok := r.errors[repository.ErrKeyDeleteRepost]; ok {
+		return err
+	}
+
+	if _, ok := r.timelineItems[postID]; !ok {
+		return repository.ErrRecordNotFound
+	}
+
+	delete(r.timelineItems, postID)
+	return nil
+}
+
+func (r *fakeTimelineitemsRepository) CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err, ok := r.errors[repository.ErrKeyCreateQuoteRepost]; ok {
+		return entity.TimelineItem{}, err
+	}
+
+	if _, ok := r.timelineItems[postID]; !ok {
+		return entity.TimelineItem{}, repository.ErrRecordNotFound
+	}
+
+	if item, _ := r.timelineItems[postID]; item.Type == entity.PostTypeRepost {
+		return entity.TimelineItem{}, repository.ErrRepostViolation
+	}
+
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return entity.TimelineItem{}, err
+	}
+	postUUID, err := uuid.Parse(postID)
+	if err != nil {
+		return entity.TimelineItem{}, err
+	}
+
+	quoteRepostID := uuid.New()
+	timelineItem := entity.TimelineItem{
+		Type:         entity.PostTypeQuoteRepost,
+		ID:           quoteRepostID,
+		AuthorID:     userUUID,
+		ParentPostID: value.NullUUID{UUID: postUUID, Valid: true},
+		Text:         text,
+		CreatedAt:    time.Now(),
+	}
+	r.timelineItems[quoteRepostID.String()] = &timelineItem
+
+	return timelineItem, nil
+}
+
+func (r *fakeTimelineitemsRepository) SetError(key string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.errors[key] = err
+}
+
+func (r *fakeTimelineitemsRepository) ClearError(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.errors, key)
+}
+
+func isRepostUniqueViolation(item entity.TimelineItem, userUUID uuid.UUID, postNullUUID value.NullUUID) bool {
+	return item.Type == entity.PostTypeRepost && item.AuthorID == userUUID && item.ParentPostID == postNullUUID
+}

--- a/go/internal/infrastructure/persistence/timelineitems.go
+++ b/go/internal/infrastructure/persistence/timelineitems.go
@@ -11,15 +11,15 @@ import (
 	"github.com/google/uuid"
 )
 
-type timelineitemsRepository struct {
+type timelineItemsRepository struct {
 	db *sql.DB
 }
 
 func NewTimelineitemsRepository(db *sql.DB) repository.TimelineItemsRepository {
-	return &timelineitemsRepository{db}
+	return &timelineItemsRepository{db}
 }
 
-func (r *timelineitemsRepository) SpecificUserPosts(userID string) ([]*entity.TimelineItem, error) {
+func (r *timelineItemsRepository) SpecificUserPosts(userID string) ([]*entity.TimelineItem, error) {
 	query := `SELECT * FROM timelineitems WHERE author_id = $1`
 
 	rows, err := r.db.Query(query, userID)
@@ -56,7 +56,9 @@ func (r *timelineitemsRepository) SpecificUserPosts(userID string) ([]*entity.Ti
 	return timelineitems, nil
 }
 
-func (r *timelineitemsRepository) UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error) {
+// This method does not use the userID argument and gets all the timelineitems in the fake repository.
+// This is to avoid timelineItems having information in the follow table.
+func (r *timelineItemsRepository) UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error) {
 	query := `
 		SELECT timelineitems.* 
 		FROM timelineitems
@@ -98,3 +100,37 @@ func (r *timelineitemsRepository) UserAndFolloweePosts(userID string) ([]*entity
 
 	return timelineitems, nil
 }
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/678
+// - Refactor CreatePost
+func (r *timelineItemsRepository) CreatePost(userID, text string) (entity.TimelineItem, error) {
+	return entity.TimelineItem{}, nil
+}
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/679
+// - Refactor DeletePost
+func (r *timelineItemsRepository) DeletePost(postID string) error {
+	return nil
+}
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/680
+// - Refactor CreateRepost
+func (r *timelineItemsRepository) CreateRepost(userID, postID string) (entity.TimelineItem, error) {
+	return entity.TimelineItem{}, nil
+}
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/681
+// - Refactor DeleteRepost
+func (r *timelineItemsRepository) DeleteRepost(postID string) error {
+	return nil
+}
+
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/682
+// - Refactor CreateQuoteRepost
+func (r *timelineItemsRepository) CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error) {
+	return entity.TimelineItem{}, nil
+}
+
+// These methods are only used in the fake implementation for testing and are unused here.
+func (r *timelineItemsRepository) SetError(key string, err error) {}
+func (r *timelineItemsRepository) ClearError(key string)          {}


### PR DESCRIPTION
## Issue Number
#668 

## Implementation Summary
This PR introduces `fakeTimelineItemsRepository`, a fake implementation of `TimelineItemsRepository`, and I added the following method.

- CreatePost(userID, text string) (entity.TimelineItem, error)
- DeletePost(postID string) error
- CreateRepost(userID, postID string) (entity.TimelineItem, error)
- DeleteRepost(postID string) error
- CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error)
- SetError(key string, err error)
- ClearError(key string)

These methods are implemented as the skeleton functionality necessary to avoid errors in the `timelineItemsRepository` while simulating repository interactions for testing and development purposes.

## Scope of Impact
Methods have been added with the fake implementation, but there is no existing code that uses them. These methods will be used in the future.

## Particular points to check
Please check if the fake implementation and the way to control behavior are appropriate.

## Test
None

## Schedule
04/12
