### PR TITLE
[Go] Write createfollowship openapi to separate handler for test isolation

### DIFF
--- a/go/cmd/main.go
+++ b/go/cmd/main.go
@@ -42,7 +42,6 @@ func main() {
 	deleteUserUsecase := interactor.NewDeleteUserUsecase(usersRepository)
 	likePostUsecase := interactor.NewLikePostUsecase(usersRepository)
 	unlikePostUsecase := interactor.NewUnlikePostUsecase(usersRepository)
-	followUserUsecase := interactor.NewFollowUserUsecase(usersRepository)
 	unfollowUserUsecase := interactor.NewUnfollowUserUsecase(usersRepository)
 	muteUserUsecase := interactor.NewMuteUserUsecase(usersRepository)
 	unmuteUserUsecase := interactor.NewUnmuteUserUsecase(usersRepository)
@@ -63,10 +62,6 @@ func main() {
 
 	mux.HandleFunc("DELETE /api/users/{id}/likes/{post_id}", func(w http.ResponseWriter, r *http.Request) {
 		handler.UnlikePost(w, r, unlikePostUsecase)
-	})
-
-	mux.HandleFunc("POST /api/users/{id}/following", func(w http.ResponseWriter, r *http.Request) {
-		handler.CreateFollowship(w, r, followUserUsecase)
 	})
 
 	mux.HandleFunc("DELETE /api/users/{source_user_id}/following/{target_user_id}", func(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/controller/handler/create_followship.go
+++ b/go/internal/controller/handler/create_followship.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"x-clone-backend/internal/application/usecase"
+	"x-clone-backend/internal/application/usecase/interactor"
+	"x-clone-backend/internal/infrastructure/persistence"
+)
+
+// CreateFollowshipHandler handles the POST /api/users/{id}/following
+type CreateFollowshipHandler struct {
+	db      *sql.DB
+	usecase usecase.FollowUserUsecase
+}
+
+// NewCreateFollowshipHandler initializes the handler with its dependencies
+func NewCreateFollowshipHandler(db *sql.DB) CreateFollowshipHandler {
+	usersRepository := persistence.NewUsersRepository(db)
+	createFollowshipUsecase := interactor.NewFollowUserUsecase(usersRepository)
+	return CreateFollowshipHandler{
+		db:      db,
+		usecase: createFollowshipUsecase,
+	}
+}
+
+// createFollowshipRequestBody is the type of the "CreateFollowship"
+// endpoint request body.
+// Successful: returns status code 201
+func (h *CreateFollowshipHandler) CreateFollowship(w http.ResponseWriter, r *http.Request, id string) {
+	var body createFollowshipRequestBody
+
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&body)
+	if err != nil {
+		http.Error(w, "Request body was invalid.", http.StatusBadRequest)
+		return
+	}
+
+	sourceUserID := id
+
+	err = h.usecase.FollowUser(sourceUserID, body.TargetUserID)
+	if err != nil {
+		http.Error(w, "Could not create followship.", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}

--- a/go/internal/controller/server.go
+++ b/go/internal/controller/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	handler.DeleteRepostHandler
 	handler.GetUserPostsTimelineHandler
 	handler.GetReverseChronologicalHomeTimelineHandler
+	handler.CreateFollowshipHandler
 }
 
 func NewServer(db *sql.DB, mu *sync.Mutex, usersChan *map[string]chan entity.TimelineEvent, authService *service.AuthService) Server {
@@ -36,5 +37,6 @@ func NewServer(db *sql.DB, mu *sync.Mutex, usersChan *map[string]chan entity.Tim
 		DeleteRepostHandler:                        handler.NewDeleteRepostHandler(db, mu, usersChan),
 		GetUserPostsTimelineHandler:                handler.NewGetUserPostsTimelineHandler(db),
 		GetReverseChronologicalHomeTimelineHandler: handler.NewGetReverseChronologicalHomeTimelineHandler(db, mu, usersChan, make(chan struct{}, 1)),
+		CreateFollowshipHandler:                    handler.NewCreateFollowshipHandler(db),
 	}
 }

--- a/go/internal/openapi/models.gen.go
+++ b/go/internal/openapi/models.gen.go
@@ -4,8 +4,28 @@
 package openapi
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/oapi-codegen/runtime"
 )
+
+// Defines values for GetUserPostsTimelineResponse1Type.
+const (
+	Post        GetUserPostsTimelineResponse1Type = "post"
+	QuoteRepost GetUserPostsTimelineResponse1Type = "quoteRepost"
+	Repost      GetUserPostsTimelineResponse1Type = "repost"
+)
+
+// CreateFollowshipRequest defines model for create_followship_request.
+type CreateFollowshipRequest struct {
+	TargetUserID string `json:"targetUserID"`
+}
+
+// CreateFollowshipResponse defines model for create_followship_response.
+type CreateFollowshipResponse struct {
+	Message string `json:"message"`
+}
 
 // CreatePostRequest defines model for create_post_request.
 type CreatePostRequest struct {
@@ -15,10 +35,24 @@ type CreatePostRequest struct {
 
 // CreatePostResponse defines model for create_post_response.
 type CreatePostResponse struct {
+	union json.RawMessage
+}
+
+// CreatePostResponse0 Response when creating a post (old schema).
+type CreatePostResponse0 struct {
 	CreatedAt time.Time `json:"created_at"`
 	Id        string    `json:"id"`
 	Text      string    `json:"text"`
 	UserId    string    `json:"user_id"`
+}
+
+// CreatePostResponse1 Response when creating a timeline item (new schema).
+type CreatePostResponse1 struct {
+	AuthorId  string    `json:"author_id"`
+	CreatedAt time.Time `json:"created_at"`
+	Id        string    `json:"id"`
+	Text      string    `json:"text"`
+	Type      string    `json:"type"`
 }
 
 // CreateQuoteRepostRequest defines model for create_quote_repost_request.
@@ -29,11 +63,26 @@ type CreateQuoteRepostRequest struct {
 
 // CreateQuoteRepostResponse defines model for create_quote_repost_response.
 type CreateQuoteRepostResponse struct {
+	union json.RawMessage
+}
+
+// CreateQuoteRepostResponse0 Response when creating a quote repost (old schema).
+type CreateQuoteRepostResponse0 struct {
 	CreatedAt time.Time `json:"created_at"`
 	Id        string    `json:"id"`
 	ParentId  string    `json:"parent_id"`
 	Text      string    `json:"text"`
 	UserId    string    `json:"user_id"`
+}
+
+// CreateQuoteRepostResponse1 Response when creating a quote repost (new schema).
+type CreateQuoteRepostResponse1 struct {
+	AuthorId     string    `json:"author_id"`
+	CreatedAt    time.Time `json:"created_at"`
+	Id           string    `json:"id"`
+	ParentPostId string    `json:"parent_post_id"`
+	Text         string    `json:"text"`
+	Type         string    `json:"type"`
 }
 
 // CreateRepostRequest defines model for create_repost_request.
@@ -43,11 +92,25 @@ type CreateRepostRequest struct {
 
 // CreateRepostResponse defines model for create_repost_response.
 type CreateRepostResponse struct {
+	union json.RawMessage
+}
+
+// CreateRepostResponse0 Response when creating a repost (old schema).
+type CreateRepostResponse0 struct {
 	CreatedAt time.Time `json:"created_at"`
 	Id        string    `json:"id"`
 	ParentId  string    `json:"parent_id"`
 	Text      string    `json:"text"`
 	UserId    string    `json:"user_id"`
+}
+
+// CreateRepostResponse1 Response when creating a repost (new schema).
+type CreateRepostResponse1 struct {
+	AuthorId     string    `json:"author_id"`
+	CreatedAt    time.Time `json:"created_at"`
+	Id           string    `json:"id"`
+	ParentPostId string    `json:"parent_post_id"`
+	Type         string    `json:"type"`
 }
 
 // CreateUserRequest defines model for create_user_request.
@@ -91,31 +154,70 @@ type FindUserByIdResponse struct {
 
 // GetReverseChronologicalHomeTimelineResponse defines model for get_reverse_chronological_home_timeline_response.
 type GetReverseChronologicalHomeTimelineResponse struct {
-	Data *struct {
-		EventType string `json:"event_type"`
-		Posts     struct {
-			CreatedAt time.Time `json:"created_at"`
-			Id        string    `json:"id"`
-			Text      string    `json:"text"`
-			UserId    string    `json:"user_id"`
-		} `json:"posts"`
-		Reposts struct {
-			CreatedAt time.Time `json:"created_at"`
-			Id        string    `json:"id"`
-			ParentId  string    `json:"parent_id"`
-			Text      string    `json:"text"`
-			UserId    string    `json:"user_id"`
-		} `json:"reposts"`
-	} `json:"data,omitempty"`
+	Data *GetReverseChronologicalHomeTimelineResponse_Data `json:"data,omitempty"`
+}
+
+// GetReverseChronologicalHomeTimelineResponseData0 defines model for .
+type GetReverseChronologicalHomeTimelineResponseData0 struct {
+	EventType string `json:"event_type"`
+	Posts     struct {
+		CreatedAt time.Time `json:"created_at"`
+		Id        string    `json:"id"`
+		Text      string    `json:"text"`
+		UserId    string    `json:"user_id"`
+	} `json:"posts"`
+	Reposts struct {
+		CreatedAt time.Time `json:"created_at"`
+		Id        string    `json:"id"`
+		ParentId  string    `json:"parent_id"`
+		Text      string    `json:"text"`
+		UserId    string    `json:"user_id"`
+	} `json:"reposts"`
+}
+
+// GetReverseChronologicalHomeTimelineResponseData1 defines model for .
+type GetReverseChronologicalHomeTimelineResponseData1 struct {
+	EventType     string `json:"event_type"`
+	Timelineitems struct {
+		AuthorId     string    `json:"author_id"`
+		CreatedAt    time.Time `json:"created_at"`
+		Id           string    `json:"id"`
+		ParentPostId *string   `json:"parent_post_id,omitempty"`
+		Text         *string   `json:"text,omitempty"`
+		Type         string    `json:"type"`
+	} `json:"timelineitems"`
+}
+
+// GetReverseChronologicalHomeTimelineResponse_Data defines model for GetReverseChronologicalHomeTimelineResponse.Data.
+type GetReverseChronologicalHomeTimelineResponse_Data struct {
+	union json.RawMessage
 }
 
 // GetUserPostsTimelineResponse defines model for get_user_posts_timeline_response.
-type GetUserPostsTimelineResponse = []struct {
+type GetUserPostsTimelineResponse struct {
+	union json.RawMessage
+}
+
+// GetUserPostsTimelineResponse0 Response when fetching user posts (old schema).
+type GetUserPostsTimelineResponse0 = []struct {
 	CreatedAt time.Time `json:"created_at"`
 	Id        string    `json:"id"`
 	Text      string    `json:"text"`
 	UserId    string    `json:"user_id"`
 }
+
+// GetUserPostsTimelineResponse1 Response when fetching timeline items (new schema).
+type GetUserPostsTimelineResponse1 = []struct {
+	AuthorId     string                            `json:"author_id"`
+	CreatedAt    time.Time                         `json:"created_at"`
+	Id           string                            `json:"id"`
+	ParentPostId *string                           `json:"parent_post_id"`
+	Text         string                            `json:"text"`
+	Type         GetUserPostsTimelineResponse1Type `json:"type"`
+}
+
+// GetUserPostsTimelineResponse1Type defines model for GetUserPostsTimelineResponse.1.Type.
+type GetUserPostsTimelineResponse1Type string
 
 // LoginRequest defines model for login_request.
 type LoginRequest struct {
@@ -146,6 +248,9 @@ type CreatePostJSONRequestBody = CreatePostRequest
 // CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 type CreateUserJSONRequestBody = CreateUserRequest
 
+// CreateFollowshipJSONRequestBody defines body for CreateFollowship for application/json ContentType.
+type CreateFollowshipJSONRequestBody = CreateFollowshipRequest
+
 // CreateQuoteRepostJSONRequestBody defines body for CreateQuoteRepost for application/json ContentType.
 type CreateQuoteRepostJSONRequestBody = CreateQuoteRepostRequest
 
@@ -154,3 +259,313 @@ type CreateRepostJSONRequestBody = CreateRepostRequest
 
 // DeleteRepostJSONRequestBody defines body for DeleteRepost for application/json ContentType.
 type DeleteRepostJSONRequestBody = DeleteRepostRequest
+
+// AsCreatePostResponse0 returns the union data inside the CreatePostResponse as a CreatePostResponse0
+func (t CreatePostResponse) AsCreatePostResponse0() (CreatePostResponse0, error) {
+	var body CreatePostResponse0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreatePostResponse0 overwrites any union data inside the CreatePostResponse as the provided CreatePostResponse0
+func (t *CreatePostResponse) FromCreatePostResponse0(v CreatePostResponse0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreatePostResponse0 performs a merge with any union data inside the CreatePostResponse, using the provided CreatePostResponse0
+func (t *CreatePostResponse) MergeCreatePostResponse0(v CreatePostResponse0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreatePostResponse1 returns the union data inside the CreatePostResponse as a CreatePostResponse1
+func (t CreatePostResponse) AsCreatePostResponse1() (CreatePostResponse1, error) {
+	var body CreatePostResponse1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreatePostResponse1 overwrites any union data inside the CreatePostResponse as the provided CreatePostResponse1
+func (t *CreatePostResponse) FromCreatePostResponse1(v CreatePostResponse1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreatePostResponse1 performs a merge with any union data inside the CreatePostResponse, using the provided CreatePostResponse1
+func (t *CreatePostResponse) MergeCreatePostResponse1(v CreatePostResponse1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreatePostResponse) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreatePostResponse) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsCreateQuoteRepostResponse0 returns the union data inside the CreateQuoteRepostResponse as a CreateQuoteRepostResponse0
+func (t CreateQuoteRepostResponse) AsCreateQuoteRepostResponse0() (CreateQuoteRepostResponse0, error) {
+	var body CreateQuoteRepostResponse0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateQuoteRepostResponse0 overwrites any union data inside the CreateQuoteRepostResponse as the provided CreateQuoteRepostResponse0
+func (t *CreateQuoteRepostResponse) FromCreateQuoteRepostResponse0(v CreateQuoteRepostResponse0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateQuoteRepostResponse0 performs a merge with any union data inside the CreateQuoteRepostResponse, using the provided CreateQuoteRepostResponse0
+func (t *CreateQuoteRepostResponse) MergeCreateQuoteRepostResponse0(v CreateQuoteRepostResponse0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateQuoteRepostResponse1 returns the union data inside the CreateQuoteRepostResponse as a CreateQuoteRepostResponse1
+func (t CreateQuoteRepostResponse) AsCreateQuoteRepostResponse1() (CreateQuoteRepostResponse1, error) {
+	var body CreateQuoteRepostResponse1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateQuoteRepostResponse1 overwrites any union data inside the CreateQuoteRepostResponse as the provided CreateQuoteRepostResponse1
+func (t *CreateQuoteRepostResponse) FromCreateQuoteRepostResponse1(v CreateQuoteRepostResponse1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateQuoteRepostResponse1 performs a merge with any union data inside the CreateQuoteRepostResponse, using the provided CreateQuoteRepostResponse1
+func (t *CreateQuoteRepostResponse) MergeCreateQuoteRepostResponse1(v CreateQuoteRepostResponse1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateQuoteRepostResponse) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateQuoteRepostResponse) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsCreateRepostResponse0 returns the union data inside the CreateRepostResponse as a CreateRepostResponse0
+func (t CreateRepostResponse) AsCreateRepostResponse0() (CreateRepostResponse0, error) {
+	var body CreateRepostResponse0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateRepostResponse0 overwrites any union data inside the CreateRepostResponse as the provided CreateRepostResponse0
+func (t *CreateRepostResponse) FromCreateRepostResponse0(v CreateRepostResponse0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateRepostResponse0 performs a merge with any union data inside the CreateRepostResponse, using the provided CreateRepostResponse0
+func (t *CreateRepostResponse) MergeCreateRepostResponse0(v CreateRepostResponse0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateRepostResponse1 returns the union data inside the CreateRepostResponse as a CreateRepostResponse1
+func (t CreateRepostResponse) AsCreateRepostResponse1() (CreateRepostResponse1, error) {
+	var body CreateRepostResponse1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateRepostResponse1 overwrites any union data inside the CreateRepostResponse as the provided CreateRepostResponse1
+func (t *CreateRepostResponse) FromCreateRepostResponse1(v CreateRepostResponse1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateRepostResponse1 performs a merge with any union data inside the CreateRepostResponse, using the provided CreateRepostResponse1
+func (t *CreateRepostResponse) MergeCreateRepostResponse1(v CreateRepostResponse1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateRepostResponse) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateRepostResponse) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetReverseChronologicalHomeTimelineResponseData0 returns the union data inside the GetReverseChronologicalHomeTimelineResponse_Data as a GetReverseChronologicalHomeTimelineResponseData0
+func (t GetReverseChronologicalHomeTimelineResponse_Data) AsGetReverseChronologicalHomeTimelineResponseData0() (GetReverseChronologicalHomeTimelineResponseData0, error) {
+	var body GetReverseChronologicalHomeTimelineResponseData0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetReverseChronologicalHomeTimelineResponseData0 overwrites any union data inside the GetReverseChronologicalHomeTimelineResponse_Data as the provided GetReverseChronologicalHomeTimelineResponseData0
+func (t *GetReverseChronologicalHomeTimelineResponse_Data) FromGetReverseChronologicalHomeTimelineResponseData0(v GetReverseChronologicalHomeTimelineResponseData0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetReverseChronologicalHomeTimelineResponseData0 performs a merge with any union data inside the GetReverseChronologicalHomeTimelineResponse_Data, using the provided GetReverseChronologicalHomeTimelineResponseData0
+func (t *GetReverseChronologicalHomeTimelineResponse_Data) MergeGetReverseChronologicalHomeTimelineResponseData0(v GetReverseChronologicalHomeTimelineResponseData0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetReverseChronologicalHomeTimelineResponseData1 returns the union data inside the GetReverseChronologicalHomeTimelineResponse_Data as a GetReverseChronologicalHomeTimelineResponseData1
+func (t GetReverseChronologicalHomeTimelineResponse_Data) AsGetReverseChronologicalHomeTimelineResponseData1() (GetReverseChronologicalHomeTimelineResponseData1, error) {
+	var body GetReverseChronologicalHomeTimelineResponseData1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetReverseChronologicalHomeTimelineResponseData1 overwrites any union data inside the GetReverseChronologicalHomeTimelineResponse_Data as the provided GetReverseChronologicalHomeTimelineResponseData1
+func (t *GetReverseChronologicalHomeTimelineResponse_Data) FromGetReverseChronologicalHomeTimelineResponseData1(v GetReverseChronologicalHomeTimelineResponseData1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetReverseChronologicalHomeTimelineResponseData1 performs a merge with any union data inside the GetReverseChronologicalHomeTimelineResponse_Data, using the provided GetReverseChronologicalHomeTimelineResponseData1
+func (t *GetReverseChronologicalHomeTimelineResponse_Data) MergeGetReverseChronologicalHomeTimelineResponseData1(v GetReverseChronologicalHomeTimelineResponseData1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetReverseChronologicalHomeTimelineResponse_Data) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetReverseChronologicalHomeTimelineResponse_Data) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetUserPostsTimelineResponse0 returns the union data inside the GetUserPostsTimelineResponse as a GetUserPostsTimelineResponse0
+func (t GetUserPostsTimelineResponse) AsGetUserPostsTimelineResponse0() (GetUserPostsTimelineResponse0, error) {
+	var body GetUserPostsTimelineResponse0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetUserPostsTimelineResponse0 overwrites any union data inside the GetUserPostsTimelineResponse as the provided GetUserPostsTimelineResponse0
+func (t *GetUserPostsTimelineResponse) FromGetUserPostsTimelineResponse0(v GetUserPostsTimelineResponse0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetUserPostsTimelineResponse0 performs a merge with any union data inside the GetUserPostsTimelineResponse, using the provided GetUserPostsTimelineResponse0
+func (t *GetUserPostsTimelineResponse) MergeGetUserPostsTimelineResponse0(v GetUserPostsTimelineResponse0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetUserPostsTimelineResponse1 returns the union data inside the GetUserPostsTimelineResponse as a GetUserPostsTimelineResponse1
+func (t GetUserPostsTimelineResponse) AsGetUserPostsTimelineResponse1() (GetUserPostsTimelineResponse1, error) {
+	var body GetUserPostsTimelineResponse1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetUserPostsTimelineResponse1 overwrites any union data inside the GetUserPostsTimelineResponse as the provided GetUserPostsTimelineResponse1
+func (t *GetUserPostsTimelineResponse) FromGetUserPostsTimelineResponse1(v GetUserPostsTimelineResponse1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetUserPostsTimelineResponse1 performs a merge with any union data inside the GetUserPostsTimelineResponse, using the provided GetUserPostsTimelineResponse1
+func (t *GetUserPostsTimelineResponse) MergeGetUserPostsTimelineResponse1(v GetUserPostsTimelineResponse1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetUserPostsTimelineResponse) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetUserPostsTimelineResponse) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}

--- a/openapi/components/requests/create_followship_request.yml
+++ b/openapi/components/requests/create_followship_request.yml
@@ -1,0 +1,7 @@
+type: object
+title: CreateFollowshipRequest
+required:
+  - targetUserID
+properties:
+  targetUserID:
+    type: string

--- a/openapi/components/responses/create_followship_response.yml
+++ b/openapi/components/responses/create_followship_response.yml
@@ -1,0 +1,7 @@
+type: object
+title: CreateFollowshipErrorResponse
+required:
+  - message
+properties:
+  message:
+    type: string

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -23,6 +23,8 @@ paths:
     $ref: ./paths/find_user_by_id.yml
   /api/login:
     $ref: ./paths/login.yml
+  /api/users/{id}/following:
+    $ref: ./paths/followship.yml
 
 components:
   schemas:
@@ -44,6 +46,10 @@ components:
       $ref: ./components/responses/create_quote_repost_response.yml
     DeleteRepostRequest:
       $ref: ./components/requests/delete_repost_request.yml
+    CreateFollowshipRequest:
+      $ref: ./components/requests/create_followship_request.yml
+    CreateFollowshipResponse:
+      $ref: ./components/responses/create_followship_response.yml
     GetReverseChronologicalHomeTimelineResponse:
       $ref: ./components/responses/get_reverse_chronological_home_timeline_response.yml
     GetReverseChronologicalHomeTimelineExample:

--- a/openapi/paths/followship.yml
+++ b/openapi/paths/followship.yml
@@ -1,0 +1,33 @@
+post:
+  tags:
+    - X-Clone
+  summary: Create a followship
+  operationId: createFollowship
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: string
+  requestBody:
+    description: JSON payload to specify target user
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/requests/create_followship_request.yml
+  responses:
+    '201':
+      description: Followship created successfully
+    '400':
+      description: Bad Request – The request body was invalid.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/responses/create_followship_response.yml
+    '500':
+      description: Internal Server Error – Could not create followship.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/responses/create_followship_response.yml


### PR DESCRIPTION
## Issue Number
#676 

## Implementation Summary
- This pull request implements the CreateFollowship handler.
- Separation of the handler (create_followship.go) for better test isolation
- Addition of the OpenAPI path definition (paths/followship.yml)
- Addition of request/response schema:
- components/requests/create_followship_request.yml
- components/responses/create_followship_response.yml
- Update to openapi.yml to register the new endpoint

## Scope of Impact

This will be executed when a user sends a POST /api/users/{id}/follow request with a valid JSON payload (target_user_id).

## Particular points to check

- Make sure the request/response structure in OpenAPI aligns with the actual handler logic
- No regression is introduced to the existing server.go or handler registration
- The new endpoint doesn’t conflict with existing user-related endpoints
- OpenAPI bundling and validation (make bundle-openapi) succeeds without errors
## Test
```
go test -v ./...
```
## Schedule
4/19

## Note
Task Instruction from Kawai
- Set openapi schema
- Create a new create_followship.go file
- Define the necessary struct(s) for the handler
- Copy and migrate the relevant function from the existing handlers to this new file
- Register the new handler in server.go
