### PR TITLE
[BFF] Implement CreateRepost

### DIFF
--- a/bff/src/schema.gql
+++ b/bff/src/schema.gql
@@ -15,12 +15,6 @@ type NullableUuid {
   Valid: Boolean!
 }
 
-type Query {
-  getUserPosts(userId: ID!): [TimelineItem!]!
-}
-
-union TimelineItem = Post | Repost | QuoteRepost
-
 type Repost {
   type: String!
   id: ID!
@@ -28,6 +22,12 @@ type Repost {
   parentPostId: NullableUuid!
   createdAt: String!
 }
+
+type Query {
+  getUserPosts(userId: ID!): [TimelineItem!]!
+}
+
+union TimelineItem = Post | Repost | QuoteRepost
 
 type QuoteRepost {
   type: String!
@@ -40,9 +40,14 @@ type QuoteRepost {
 
 type Mutation {
   createPost(createPostInput: CreatePostInput!): Post!
+  createRepost(userId: ID!, createRepostInput: CreateRepostInput!): Repost!
 }
 
 input CreatePostInput {
   user_id: ID!
   text: String!
+}
+
+input CreateRepostInput {
+  post_id: String!
 }

--- a/bff/src/timeline/inputs/create-repost.input.ts
+++ b/bff/src/timeline/inputs/create-repost.input.ts
@@ -1,0 +1,7 @@
+import { Field, ID, InputType } from "@nestjs/graphql";
+
+@InputType()
+export class CreateRepostInput {
+  @Field()
+  post_id: string;
+}

--- a/bff/src/timeline/timeline.resolver.ts
+++ b/bff/src/timeline/timeline.resolver.ts
@@ -1,6 +1,8 @@
 import { Args, ID, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { CreatePostInput } from "./inputs/create-post.input";
+import { CreateRepostInput } from "./inputs/create-repost.input";
 import { Post } from "./models/post.model";
+import { Repost } from "./models/repost.model";
 import { TimelineItem } from "./models/timeline-item.model";
 import { TimelineService } from "./timeline.service";
 
@@ -20,5 +22,13 @@ export class TimelineResolver {
     @Args("createPostInput") createPostInput: CreatePostInput,
   ): Promise<Post> {
     return this.timelineService.createPost(createPostInput);
+  }
+
+  @Mutation(() => Repost)
+  async createRepost(
+    @Args("userId", { type: () => ID }) userId: string,
+    @Args("createRepostInput") createRepostInput: CreateRepostInput,
+  ): Promise<Post> {
+    return this.timelineService.createRepost(userId, createRepostInput);
   }
 }

--- a/bff/src/timeline/timeline.service.ts
+++ b/bff/src/timeline/timeline.service.ts
@@ -2,6 +2,7 @@ import { HttpService } from "@nestjs/axios";
 import { Injectable } from "@nestjs/common";
 import { firstValueFrom } from "rxjs";
 import { CreatePostInput } from "./inputs/create-post.input";
+import { CreateRepostInput } from "./inputs/create-repost.input";
 import { Post } from "./models/post.model";
 import { TimelineItem } from "./models/timeline-item.model";
 
@@ -34,6 +35,26 @@ export class TimelineService {
   async createPost(createPostInput: CreatePostInput): Promise<Post> {
     const { data } = await firstValueFrom(
       this.httpService.post<Post>("/api/posts", createPostInput),
+    );
+
+    return data;
+  }
+
+  /**
+   * Creates a new repost by sending the data to the backend API.
+   *
+   * @param createRepostInput - An object containing the necessary data for creating a repost (e.g., postId).
+   * @returns A promise that resolves to the newly created Repost object as returned by the backend.
+   */
+  async createRepost(
+    userId: string,
+    createRepostInput: CreateRepostInput,
+  ): Promise<Post> {
+    const { data } = await firstValueFrom(
+      this.httpService.post<Post>(
+        `/api/users/${userId}/reposts`,
+        createRepostInput,
+      ),
     );
 
     return data;


### PR DESCRIPTION
## Issue Number
#691 

## Implementation Summary
This pull request introduces the `CreateRepost` mutation.

- Implemented the GraphQL resolver and its underlying service to handle communication with the backend.

## Scope of Impact
This change introduces new GraphQL operations:
- `CreateRepost(userId: string, input: CreateRepostInput): Repost` — Mutation for creating a new repost.

## Points for Review
Please verify that the query and mutation execute correctly by following these steps:

1. Install dependencies:
   ```sh
   yarn
   ```

2. Start the NestJS server:
   ```sh
   yarn start
   ```

3. Start the backend server (in the `go` directory):
   ```sh
   make start
   make exec-app
   go run ./cmd
   ```

4. Open Apollo Sandbox at [http://localhost:8080/graphql](http://localhost:8080/graphql).

5. Execute the query and mutation. You can set the request parameters in the **Variables** section.

**GraphQL Query:**
```graphql
mutation Mutation($userId: ID!, $createRepostInput: CreateRepostInput!) {
  createRepost(userId: $userId, createRepostInput: $createRepostInput) {
    authorId
    createdAt
    id
    parentPostId {
      UUID
      Valid
    }
  }
}


```

**GraphQL Mutation:**
```graphql
mutation CreatePost($createPostInput: CreatePostInput!) {
  createPost(createPostInput: $createPostInput) {
    type
    id
    authorId
    text
    createdAt
  }
}
```

**Variables:**
```json
{
  "userId": "", // your user ID
  "createRepostInput": {
    "post_id": "" // your post ID
  }
}
```

6. You should see the response displayed in the right-hand panel.
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/76724201-670d-49ae-856e-c210e40aa337" />


## Test
Unit tests will be added in #688.

## Schedule
4/25
