### PR TITLE
[Infra] Add userpool that permit user to access S3

### DIFF
--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -22,4 +22,6 @@ module "cognito" {
   user_pool_name = var.user_pool_name
   callback_urls  = var.callback_urls
   logout_urls    = var.logout_urls
+  region = var.region
+  bucket_name = module.s3.bucket_name
 }

--- a/terraform/environments/prd/variables.tf
+++ b/terraform/environments/prd/variables.tf
@@ -28,3 +28,8 @@ variable "logout_urls" {
   description = "URL to redirect to after logout"
   type        = list(string)
 }
+
+variable "region" {
+  description = "The region name"
+  type = string
+}

--- a/terraform/environments/prd/vars.tfvars.sample
+++ b/terraform/environments/prd/vars.tfvars.sample
@@ -5,3 +5,4 @@ user_pool_name     = "example-user-pool"
 identity_pool_name = "example-identity-pool"
 callback_urls = ["http://example.com"]
 logout_urls = ["http://example.com"]
+region = "ap-northeast-1"

--- a/terraform/modules/cognito/variables.tf
+++ b/terraform/modules/cognito/variables.tf
@@ -17,3 +17,13 @@ variable "env" {
   type        = string
   description = "Deployment environment name (e.g. dev, staging, prod)."
 }
+
+variable "region" {
+  description = "The region name"
+  type = string
+}
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket to allow access to."
+  type        = string
+}

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "The bucket name."
+  value = aws_s3_bucket.static.bucket
+}


### PR DESCRIPTION
## Issue Number
#710 

## Implementation Summary
Enabled access control where only users authenticated through Cognito and the Identity Pool can access the S3 bucket.

- Created a User Pool and User Pool Client supporting OAuth 2.0 Authorization Code Flow.
- Configured an Identity Pool to issue temporary AWS credentials to logged-in users.
- Set up IAM roles and policies to restrict S3 access to authenticated users only.

## Scope of Impact
Changes apply only when deploying or destroying the Cognito authentication infrastructure using Terraform.
Affects creation and deletion of Cognito User Pool, User Pool Client, Identity Pool, IAM Roles, and their permissions related to S3 access.

## Particular points to check
Confirm that users authenticated via Cognito Hosted UI can successfully obtain temporary AWS credentials.
Confirm that authenticated users can list and get objects from the designated S3 bucket.

## Test
**AWS side**
1. `terraform apply`
2. create user(manual)
![image](https://github.com/user-attachments/assets/02b3a4c0-6230-462e-b5bc-35b7f6845a13)

3.  set up managed domain(manual)
![image](https://github.com/user-attachments/assets/22147d5f-c87c-4085-ad4d-81be0128de3a)
4. Upload file to S3(manual)

**Go side**
[src](https://github.com/Rwatana/login-app)
1. `go run main.go`
2. login by user you created

![image](https://github.com/user-attachments/assets/f65a7335-bc9a-498b-b921-54a73b539187)
![image](https://github.com/user-attachments/assets/86c3e19b-57aa-46c3-8c2e-302895df7054)

4. you can see the contents of S3(success case)
![image](https://github.com/user-attachments/assets/ab71dea5-bbb9-4bd4-8701-5419df87becd)

5. go to redirect page directly(failure case)
![image](https://github.com/user-attachments/assets/8a38276a-5f06-4af3-9225-c87b50bc85db)


## Schedule
5/3