### PR TITLE
[Infra] Enable SSH access to EC2 and verify successful instance setup

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,3 +27,10 @@ $ terraform plan -var-file=vars.tfvars
 ```
 $ terraform apply -var-file=vars.tfvars
 ```
+
+# Start Backend Server
+1. Connect to the EC2 instance using EC2 Instance Connect. (See [Connect using the Amazon EC2 console](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html#ec2-instance-connect-connecting-console) for instructions.)
+2. Start the backend server:
+```sh
+docker exec -it x_app go run ./cmd/main.go
+```

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -13,7 +13,7 @@ module "ec2" {
   source    = "../../modules/ec2"
   env       = var.env
   vpc_id    = module.vpc.vpc_id
-  subnet_id = module.vpc.private_subnet_id
+  subnet_id = module.vpc.public_subnet_id
 }
 
 module "cognito" {

--- a/terraform/modules/cognito/main.tf
+++ b/terraform/modules/cognito/main.tf
@@ -10,9 +10,9 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_cognito_user_pool" "user_pool" {
-  name = "${var.user_pool_name}-${var.env}"
+  name                       = "${var.user_pool_name}-${var.env}"
   sms_authentication_message = "Your verification code is {####}."
-  mfa_configuration = "OFF"
+  mfa_configuration          = "OFF"
 
   lifecycle {
     prevent_destroy = false
@@ -46,8 +46,8 @@ resource "aws_cognito_user_pool" "user_pool" {
 
   schema {
     attribute_data_type = "String"
-    name     = "email"
-    required = true
+    name                = "email"
+    required            = true
   }
 
   username_configuration {

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -6,11 +6,39 @@ resource "aws_vpc" "main" {
   }
 }
 
-resource "aws_subnet" "private" {
-  vpc_id     = aws_vpc.main.id
-  cidr_block = "10.0.0.0/25"
+resource "aws_internet_gateway" "gateway" {
+  vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.env}-x-clone-private-subnet"
+    Name = "${var.env}-x-clone-internet-gateway"
   }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.0.0/25"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.env}-x-clone-public-subnet"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.env}-x-clone-public-route-table"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route" "route" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gateway.id
 }

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -3,7 +3,7 @@ output "vpc_id" {
   value       = aws_vpc.main.id
 }
 
-output "private_subnet_id" {
-  description = "The private subnet ID"
-  value       = aws_subnet.private.id
+output "public_subnet_id" {
+  description = "The public subnet ID"
+  value       = aws_subnet.public.id
 }


### PR DESCRIPTION
## Issue Number
#699 

## Implementation Summary
This PR enables SSH access to the backend EC2 instance by introducing an Internet Gateway and configuring the route table.
Additionally, `user_data` has been added to allow the EC2 instance to automatically clone the Twitter-Clone repository and run the backend using Docker Compose.

## Scope of Impact
This setup is executed when you run terraform apply.

## Particular points to check
If the network setup is appropriate.

## Test
1. Execute the Terraform actions
```
cd terraform/environments/prd
terraform init
terraform apply -var-file=vars.tfvars
```
2. Open the AWS console and connect to the instance.
![スクリーンショット 2025-04-28 20 39 57](https://github.com/user-attachments/assets/69f6bc2c-1aa7-4f7a-97c1-ad5cb3d02726)
![スクリーンショット 2025-04-28 20 39 36](https://github.com/user-attachments/assets/1390caff-43ce-4dc8-8637-98d461585a2c)

3. Run the app
```sh
docker exec -it x_app go run ./cmd/main.go
```
4. Check if the app runs properly by sending a POST request.
```
curl --location 'http://{The IP address of your instance}:80/api/users' \
--header 'Content-Type: application/json' \
--data '{
    "username": "test",
    "display_name": "test",
    "password": "password"
}
'
```

## Schedule
The date and time you want to merge.
