### PR TITLE
[Go] Change the type of ID from uuid.UUID to string

### DIFF
--- a/go/internal/application/service/auth.go
+++ b/go/internal/application/service/auth.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -52,12 +51,12 @@ func ExtractTokenFromHeader(r *http.Request) (string, error) {
 }
 
 // GenerateJWT generates a JWT with user ID and username
-func (s *AuthService) GenerateJWT(id uuid.UUID, username string) (string, error) {
+func (s *AuthService) GenerateJWT(userID string, username string) (string, error) {
 	// Set payload (claims)
 	claims := UserClaims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   id.String(),
+			Subject:   userID,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(jwtExpirationDuration)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},

--- a/go/internal/application/service/auth_test.go
+++ b/go/internal/application/service/auth_test.go
@@ -13,7 +13,7 @@ func TestGenerateJWT(t *testing.T) {
 	secretKey := "test_secret_key"
 	authService := NewAuthService(secretKey)
 
-	userID := uuid.New()
+	userID := uuid.NewString()
 	username := "test_user"
 
 	signedToken, err := authService.GenerateJWT(userID, username)
@@ -31,7 +31,7 @@ func TestValidateJWT(t *testing.T) {
 	secretKey := "test_secret_key"
 	authService := NewAuthService(secretKey)
 
-	userID := uuid.New()
+	userID := uuid.NewString()
 	username := "test_user"
 
 	signedToken, err := authService.GenerateJWT(userID, username)
@@ -44,7 +44,7 @@ func TestValidateJWT(t *testing.T) {
 		t.Fatalf("Expected no error, but got: %v", err)
 	}
 
-	if extractedUserID != userID.String() {
+	if extractedUserID != userID {
 		t.Errorf("Expected user ID %v, but got %v", userID, extractedUserID)
 	}
 }
@@ -67,7 +67,7 @@ func TestInvalidSignatureJWT(t *testing.T) {
 	secretKey := "test_secret_key"
 	authService := NewAuthService(secretKey)
 
-	userID := uuid.New()
+	userID := uuid.NewString()
 	username := "test_user"
 
 	signedToken, err := authService.GenerateJWT(userID, username)
@@ -88,7 +88,7 @@ func generateExpiredJWT(secretKey string) string {
 	claims := UserClaims{
 		Username: "test_user",
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   uuid.New().String(),
+			Subject:   uuid.NewString(),
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
 		},

--- a/go/internal/application/usecase/create_post.go
+++ b/go/internal/application/usecase/create_post.go
@@ -1,11 +1,9 @@
 package usecase
 
 import (
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/domain/entity"
 )
 
 type CreatePostUsecase interface {
-	CreatePost(userID uuid.UUID, text string) (entity.TimelineItem, error)
+	CreatePost(userID, text string) (entity.TimelineItem, error)
 }

--- a/go/internal/application/usecase/interactor/create_post.go
+++ b/go/internal/application/usecase/interactor/create_post.go
@@ -3,8 +3,6 @@ package interactor
 import (
 	"errors"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/repository"
@@ -20,7 +18,7 @@ func NewCreatePostUsecase(timelineItemsRepository repository.TimelineItemsReposi
 	}
 }
 
-func (u createPostUsecase) CreatePost(userID uuid.UUID, text string) (entity.TimelineItem, error) {
+func (u createPostUsecase) CreatePost(userID, text string) (entity.TimelineItem, error) {
 	var post entity.TimelineItem
 
 	if len(text) > entity.PostTextMaxLength {

--- a/go/internal/application/usecase/interactor/like_post.go
+++ b/go/internal/application/usecase/interactor/like_post.go
@@ -1,8 +1,6 @@
 package interactor
 
 import (
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/repository"
 )
@@ -15,7 +13,7 @@ func NewLikePostUsecase(usersRepository repository.UsersRepository) usecase.Like
 	return &likePostUsecase{usersRepository: usersRepository}
 }
 
-func (p *likePostUsecase) LikePost(userID string, postID uuid.UUID) error {
+func (p *likePostUsecase) LikePost(userID string, postID string) error {
 	err := p.usersRepository.LikePost(nil, userID, postID)
 	return err
 }

--- a/go/internal/application/usecase/like_post.go
+++ b/go/internal/application/usecase/like_post.go
@@ -1,9 +1,5 @@
 package usecase
 
-import (
-	"github.com/google/uuid"
-)
-
 type LikePostUsecase interface {
-	LikePost(userID string, postID uuid.UUID) error
+	LikePost(userID string, postID string) error
 }

--- a/go/internal/controller/handler/create_post.go
+++ b/go/internal/controller/handler/create_post.go
@@ -5,13 +5,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
-	"x-clone-backend/internal/application/usecase/interactor"
 	"x-clone-backend/internal/controller/transfer"
 	"x-clone-backend/internal/domain/entity"
-	"x-clone-backend/internal/domain/repository"
 	"x-clone-backend/internal/openapi"
 )
 
@@ -20,16 +16,16 @@ type CreatePostHandler struct {
 	createPostUsecase         usecase.CreatePostUsecase
 }
 
-func NewCreatePostHandler(updateNotificationUsecase usecase.UpdateNotificationUsecase, repo repository.TimelineItemsRepository) CreatePostHandler {
+func NewCreatePostHandler(updateNotificationUsecase usecase.UpdateNotificationUsecase, createPostUsecase usecase.CreatePostUsecase) CreatePostHandler {
 	return CreatePostHandler{
-		updateNotificationUsecase: updateNotificationUsecase,
-		createPostUsecase:         interactor.NewCreatePostUsecase(repo),
+		updateNotificationUsecase,
+		createPostUsecase,
 	}
 }
 
 // CreatePost creates a new post with the specified user_id and text,
 // then, inserts it into posts table.
-func (h *CreatePostHandler) CreatePost(w http.ResponseWriter, r *http.Request, userID uuid.UUID) {
+func (h *CreatePostHandler) CreatePost(w http.ResponseWriter, r *http.Request, userID string) {
 	var body openapi.CreatePostRequest
 
 	decoder := json.NewDecoder(r.Body)
@@ -53,7 +49,7 @@ func (h *CreatePostHandler) CreatePost(w http.ResponseWriter, r *http.Request, u
 		return
 	}
 
-	go h.updateNotificationUsecase.SendNotification(userID.String(), entity.PostCreated, &post)
+	go h.updateNotificationUsecase.SendNotification(userID, entity.PostCreated, &post)
 
 	res := transfer.ToCreatePostResponse(&post)
 

--- a/go/internal/controller/handler/create_quote_repost.go
+++ b/go/internal/controller/handler/create_quote_repost.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/value"
@@ -29,7 +27,7 @@ func NewCreateQuoteRepostHandler(db *sql.DB, updateNotificationUsecase usecase.U
 
 // CreateQuoteRepost creates a new quote repost with the specified post_id and user_id,
 // then, inserts it into reposts table.
-func (h *CreateQuoteRepostHandler) CreateQuoteRepost(w http.ResponseWriter, r *http.Request, userIDStr string) {
+func (h *CreateQuoteRepostHandler) CreateQuoteRepost(w http.ResponseWriter, r *http.Request, userID string) {
 	var body openapi.CreateQuoteRepostRequest
 
 	decoder := json.NewDecoder(r.Body)
@@ -39,28 +37,16 @@ func (h *CreateQuoteRepostHandler) CreateQuoteRepost(w http.ResponseWriter, r *h
 		return
 	}
 
-	userID, err := uuid.Parse(userIDStr)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a userID (ID: %s)\n", userIDStr), http.StatusBadRequest)
-		return
-	}
-
-	PostID, err := uuid.Parse(body.PostId)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a PostId (ID: %s)\n", body.PostId), http.StatusBadRequest)
-		return
-	}
-
 	query := `INSERT INTO timelineitems (type, author_id, parent_post_id ,text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
 
 	var (
-		id        uuid.UUID
+		id        string
 		createdAt time.Time
 	)
 
 	postType := entity.PostTypeQuoteRepost
 
-	err = h.db.QueryRow(query, postType, userID, PostID, body.Text).Scan(&id, &createdAt)
+	err = h.db.QueryRow(query, postType, userID, body.PostId, body.Text).Scan(&id, &createdAt)
 	if err != nil {
 		http.Error(w, fmt.Sprintln("Could not create a quote repost."), http.StatusInternalServerError)
 		return
@@ -70,12 +56,12 @@ func (h *CreateQuoteRepostHandler) CreateQuoteRepost(w http.ResponseWriter, r *h
 		Type:         postType,
 		ID:           id,
 		AuthorID:     userID,
-		ParentPostID: value.NullUUID{UUID: PostID, Valid: true},
+		ParentPostID: value.NullUUID{UUID: body.PostId, Valid: true},
 		Text:         body.Text,
 		CreatedAt:    createdAt,
 	}
 
-	go h.updateNotificationUsecase.SendNotification(userIDStr, entity.QuoteRepostCreated, &quoteRepost)
+	go h.updateNotificationUsecase.SendNotification(userID, entity.QuoteRepostCreated, &quoteRepost)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/go/internal/controller/handler/create_repost.go
+++ b/go/internal/controller/handler/create_repost.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/value"
@@ -29,7 +27,7 @@ func NewCreateRepostHandler(db *sql.DB, updateNotificationUsecase usecase.Update
 
 // CreateRepost creates a new repost with the specified post_id and user_id,
 // then, inserts it into reposts table.
-func (h *CreateRepostHandler) CreateRepost(w http.ResponseWriter, r *http.Request, userIDStr string) {
+func (h *CreateRepostHandler) CreateRepost(w http.ResponseWriter, r *http.Request, userID string) {
 	var body openapi.CreateRepostRequest
 
 	decoder := json.NewDecoder(r.Body)
@@ -39,29 +37,17 @@ func (h *CreateRepostHandler) CreateRepost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	userID, err := uuid.Parse(userIDStr)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a userID (ID: %s)\n", userIDStr), http.StatusBadRequest)
-		return
-	}
-
-	PostID, err := uuid.Parse(body.PostId)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a PostId (ID: %s)\n", body.PostId), http.StatusBadRequest)
-		return
-	}
-
 	query := `INSERT INTO timelineitems (type, author_id, parent_post_id ,text) VALUES ($1, $2, $3, $4) RETURNING id, created_at`
 
 	var (
-		id        uuid.UUID
+		id        string
 		createdAt time.Time
 	)
 
 	postType := entity.PostTypeRepost
 	text := ""
 
-	err = h.db.QueryRow(query, postType, userID, PostID, text).Scan(&id, &createdAt)
+	err = h.db.QueryRow(query, postType, userID, body.PostId, text).Scan(&id, &createdAt)
 	if err != nil {
 		http.Error(w, fmt.Sprintln("Could not create a repost."), http.StatusInternalServerError)
 		return
@@ -71,12 +57,12 @@ func (h *CreateRepostHandler) CreateRepost(w http.ResponseWriter, r *http.Reques
 		Type:         postType,
 		ID:           id,
 		AuthorID:     userID,
-		ParentPostID: value.NullUUID{UUID: PostID, Valid: true},
+		ParentPostID: value.NullUUID{UUID: body.PostId, Valid: true},
 		Text:         text,
 		CreatedAt:    createdAt,
 	}
 
-	go h.updateNotificationUsecase.SendNotification(userIDStr, entity.RepostCreated, &repost)
+	go h.updateNotificationUsecase.SendNotification(userID, entity.RepostCreated, &repost)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/go/internal/controller/handler/delete_repost.go
+++ b/go/internal/controller/handler/delete_repost.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/value"
@@ -30,19 +28,13 @@ func NewDeleteRepostHandler(db *sql.DB, updateNotificationUsecase usecase.Update
 
 // DeleteRepost deletes a repost with the specified post ID.
 // If the post doesn't exist, it returns 404 error.
-func (h *DeleteRepostHandler) DeleteRepost(w http.ResponseWriter, r *http.Request, userIDStr string, parentIDStr string) {
+func (h *DeleteRepostHandler) DeleteRepost(w http.ResponseWriter, r *http.Request, userID, parentID string) {
 	var body openapi.DeleteRepostRequest
 
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&body)
 	if err != nil {
 		http.Error(w, fmt.Sprintln("Request body was invalid."), http.StatusBadRequest)
-		return
-	}
-
-	RepostID, err := uuid.Parse(body.RepostId)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a RepostId (ID: %s)\n", body.RepostId), http.StatusBadRequest)
 		return
 	}
 
@@ -54,39 +46,27 @@ func (h *DeleteRepostHandler) DeleteRepost(w http.ResponseWriter, r *http.Reques
 		createdAt time.Time
 	)
 
-	err = h.db.QueryRow(query, RepostID).Scan(&postType, &text, &createdAt)
+	err = h.db.QueryRow(query, body.RepostId).Scan(&postType, &text, &createdAt)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			http.Error(w, fmt.Sprintf("No row found to delete: (repost id: %s)\n", RepostID), http.StatusNotFound)
+			http.Error(w, fmt.Sprintf("No row found to delete: (repost id: %s)\n", body.RepostId), http.StatusNotFound)
 		default:
-			http.Error(w, fmt.Sprintf("Could not delete a repost: (repost id: %s)\n", RepostID), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("Could not delete a repost: (repost id: %s)\n", body.RepostId), http.StatusInternalServerError)
 		}
-		return
-	}
-
-	userID, err := uuid.Parse(userIDStr)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a userID (ID: %s)\n", userIDStr), http.StatusBadRequest)
-		return
-	}
-
-	parentID, err := uuid.Parse(parentIDStr)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not parse a parentID (ID: %s)\n", parentIDStr), http.StatusBadRequest)
 		return
 	}
 
 	timelineitem := entity.TimelineItem{
 		Type:         postType,
-		ID:           RepostID,
+		ID:           body.RepostId,
 		AuthorID:     userID,
 		ParentPostID: value.NullUUID{UUID: parentID, Valid: true},
 		Text:         text,
 		CreatedAt:    createdAt,
 	}
 
-	go h.updateNotificationUsecase.SendNotification(userIDStr, entity.RepostDeleted, &timelineitem)
+	go h.updateNotificationUsecase.SendNotification(userID, entity.RepostDeleted, &timelineitem)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/controller/handler/handlers.go
+++ b/go/internal/controller/handler/handlers.go
@@ -8,8 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/application/usecase"
 	"x-clone-backend/internal/domain/entity"
 )
@@ -55,13 +53,9 @@ func DeletePost(w http.ResponseWriter, r *http.Request, db *sql.DB, updateNotifi
 		return
 	}
 
-	post.ID, err = uuid.Parse(postID)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not delete a post (ID: %s)\n", postID), http.StatusInternalServerError)
-		return
-	}
+	post.ID = postID
 
-	go updateNotificationUsecase.SendNotification(post.AuthorID.String(), entity.PostDeleted, &post)
+	go updateNotificationUsecase.SendNotification(post.AuthorID, entity.PostDeleted, &post)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/controller/handler/types.go
+++ b/go/internal/controller/handler/types.go
@@ -1,13 +1,9 @@
 package handler
 
-import (
-	"github.com/google/uuid"
-)
-
 // likePostRequestBody is the type of the "LikePost"
 // endpoint request body.
 type likePostRequestBody struct {
-	PostID uuid.UUID `json:"post_id,omitempty"`
+	PostID string `json:"post_id,omitempty"`
 }
 
 // createFollowshipRequestBody is the type of the "CreateFollowship"

--- a/go/internal/controller/handler/verify_session_test.go
+++ b/go/internal/controller/handler/verify_session_test.go
@@ -51,7 +51,7 @@ func TestVerifySessionHandler(t *testing.T) {
 			t.Fatalf("Failed to unmarshal response body: %v", err)
 		}
 		if resp.User.Id != user.ID {
-			t.Errorf("expected user ID %s, got %s", user.ID.String(), resp.User.Id)
+			t.Errorf("expected user ID %s, got %s", user.ID, resp.User.Id)
 		}
 	})
 
@@ -61,7 +61,7 @@ func TestVerifySessionHandler(t *testing.T) {
 		userByUserIDUsecase := interactor.NewUserByUserIDUsecase(usersRepository)
 		verifySessionHandler := NewVerifySessionHandler(authService, userByUserIDUsecase)
 
-		token, _ := authService.GenerateJWT(uuid.New(), "nonexistentuser")
+		token, _ := authService.GenerateJWT(uuid.NewString(), "nonexistentuser")
 
 		req := httptest.NewRequest(http.MethodGet, "/api/session/verify", nil)
 		req.Header.Set("Content-Type", "application/json")
@@ -81,7 +81,7 @@ func TestVerifySessionHandler(t *testing.T) {
 		userByUserIDUsecase := interactor.NewUserByUserIDUsecase(usersRepository)
 		verifySessionHandler := NewVerifySessionHandler(authService, userByUserIDUsecase)
 
-		token, _ := createExpiredToken(uuid.New(), "testuser")
+		token, _ := createExpiredToken(uuid.NewString(), "testuser")
 
 		req := httptest.NewRequest(http.MethodGet, "/api/session/verify", nil)
 		req.Header.Set("Content-Type", "application/json")
@@ -96,11 +96,11 @@ func TestVerifySessionHandler(t *testing.T) {
 	})
 }
 
-func createExpiredToken(userID uuid.UUID, username string) (string, error) {
+func createExpiredToken(userID string, username string) (string, error) {
 	expiredClaims := service.UserClaims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   userID.String(),
+			Subject:   userID,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
 		},

--- a/go/internal/controller/middleware/auth_test.go
+++ b/go/internal/controller/middleware/auth_test.go
@@ -17,7 +17,7 @@ func TestJWTMiddleware(t *testing.T) {
 	secretKey := "test_secret_key"
 	authService := service.NewAuthService(secretKey)
 
-	userID := uuid.New()
+	userID := uuid.NewString()
 	tokenString, _ := authService.GenerateJWT(userID, "test_user")
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,8 +28,8 @@ func TestJWTMiddleware(t *testing.T) {
 			return
 		}
 
-		if userIDFromContext != userID.String() {
-			t.Errorf("Expected user ID '%s', got '%s'", userID.String(), userIDFromContext)
+		if userIDFromContext != userID {
+			t.Errorf("Expected user ID '%s', got '%s'", userID, userIDFromContext)
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/go/internal/controller/transfer/to_create_user_response.go
+++ b/go/internal/controller/transfer/to_create_user_response.go
@@ -1,10 +1,6 @@
 package transfer
 
 import (
-	"time"
-
-	openapi_types "github.com/oapi-codegen/runtime/types"
-
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/openapi"
 )
@@ -12,15 +8,7 @@ import (
 func ToCreateUserResponse(in *entity.User, token string) *openapi.CreateUserResponse {
 	return &openapi.CreateUserResponse{
 		Token: token,
-		User: struct {
-			Bio         string             `json:"bio"`
-			CreatedAt   time.Time          `json:"createdAt"`
-			DisplayName string             `json:"displayName"`
-			Id          openapi_types.UUID `json:"id"`
-			IsPrivate   bool               `json:"isPrivate"`
-			UpdatedAt   time.Time          `json:"updatedAt"`
-			Username    string             `json:"username"`
-		}{
+		User: openapi.User{
 			Bio:         in.Bio,
 			CreatedAt:   in.CreatedAt,
 			DisplayName: in.DisplayName,

--- a/go/internal/controller/transfer/to_find_user_by_id_response.go
+++ b/go/internal/controller/transfer/to_find_user_by_id_response.go
@@ -10,7 +10,7 @@ func ToFindUserByIDResponse(in *entity.User) *openapi.FindUserByIdResponse {
 		Bio:         in.Bio,
 		CreatedAt:   in.CreatedAt,
 		DisplayName: in.DisplayName,
-		Id:          in.ID.String(),
+		Id:          in.ID,
 		IsPrivate:   in.IsPrivate,
 		UpdatedAt:   in.UpdatedAt,
 		Username:    in.Username,

--- a/go/internal/domain/entity/timeline_item.go
+++ b/go/internal/domain/entity/timeline_item.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"x-clone-backend/internal/domain/value"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -23,8 +21,8 @@ const (
 // AuthorID is the ID of the author of the timeline item.
 type TimelineItem struct {
 	Type         string         `json:"type"`
-	ID           uuid.UUID      `json:"id"`
-	AuthorID     uuid.UUID      `json:"authorId"`
+	ID           string         `json:"id"`
+	AuthorID     string         `json:"authorId"`
 	ParentPostID value.NullUUID `json:"parentPostId,omitzero"`
 	Text         string         `json:"text,omitzero"`
 	CreatedAt    time.Time      `json:"createdAt"`

--- a/go/internal/domain/entity/user.go
+++ b/go/internal/domain/entity/user.go
@@ -2,8 +2,6 @@ package entity
 
 import (
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // User represents an entry of `users` table.
@@ -18,12 +16,12 @@ import (
 //
 // For more information on terminology, refer to: https://help.twitter.com/en/resources/glossary.
 type User struct {
-	ID          uuid.UUID `json:"id"`
+	ID          string    `json:"id"`
 	Username    string    `json:"username"`
+	Password    string    `json:"-"`
 	DisplayName string    `json:"displayName"`
 	Bio         string    `json:"bio"`
 	IsPrivate   bool      `json:"isPrivate"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
-	Password    string    `json:"-"`
 }

--- a/go/internal/domain/repository/timeline_items.go
+++ b/go/internal/domain/repository/timeline_items.go
@@ -1,15 +1,13 @@
 package repository
 
 import (
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/domain/entity"
 )
 
 type TimelineItemsRepository interface {
 	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
 	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
-	CreatePost(userID uuid.UUID, text string) (entity.TimelineItem, error)
+	CreatePost(userID, text string) (entity.TimelineItem, error)
 	DeletePost(postID string) error
 	CreateRepost(userID, postID string) (entity.TimelineItem, error)
 	DeleteRepost(postID string) error

--- a/go/internal/domain/repository/users.go
+++ b/go/internal/domain/repository/users.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 
 	"x-clone-backend/internal/domain/entity"
-
-	"github.com/google/uuid"
 )
 
 type UsersRepository interface {
@@ -15,8 +13,8 @@ type UsersRepository interface {
 	DeleteUser(tx *sql.Tx, userID string) error
 	UserByUserID(tx *sql.Tx, userID string) (entity.User, error)
 	UserByUsername(tx *sql.Tx, userName string) (entity.User, error)
-	LikePost(tx *sql.Tx, userID string, postID uuid.UUID) error
-	UnlikePost(tx *sql.Tx, userID string, postID string) error
+	LikePost(tx *sql.Tx, userID, postID string) error
+	UnlikePost(tx *sql.Tx, userID, postID string) error
 	FollowUser(tx *sql.Tx, sourceUserID, targetUserID string) error
 	UnfollowUser(tx *sql.Tx, sourceUserID, targetUserID string) error
 	Followees(tx *sql.Tx, targetUserID string) ([]string, error)

--- a/go/internal/domain/value/nulluuid.go
+++ b/go/internal/domain/value/nulluuid.go
@@ -2,25 +2,29 @@ package value
 
 import "github.com/google/uuid"
 
-type NullUUID uuid.NullUUID
+type NullUUID struct {
+	UUID  string
+	Valid bool
+}
 
 func (u NullUUID) IsZero() bool {
 	return !u.Valid
 }
 
 // Scan implements the SQL driver.Scanner interface.
-func (nu *NullUUID) Scan(value interface{}) error {
+func (nu *NullUUID) Scan(value any) error {
 	if value == nil {
-		nu.UUID, nu.Valid = uuid.Nil, false
+		nu.UUID, nu.Valid = uuid.Nil.String(), false
 		return nil
 	}
 
-	err := nu.UUID.Scan(value)
+	var u uuid.UUID
+	err := u.Scan(value)
 	if err != nil {
 		nu.Valid = false
 		return err
 	}
 
-	nu.Valid = true
+	nu.UUID, nu.Valid = u.String(), true
 	return nil
 }

--- a/go/internal/infrastructure/fake/users.go
+++ b/go/internal/infrastructure/fake/users.go
@@ -48,7 +48,7 @@ func (r *fakeUsersRepository) CreateUser(tx *sql.Tx, username, displayName, pass
 	}
 
 	user := entity.User{
-		ID:          uuid.New(),
+		ID:          uuid.NewString(),
 		Username:    username,
 		DisplayName: displayName,
 		Password:    password,
@@ -63,7 +63,7 @@ func (r *fakeUsersRepository) CreateUser(tx *sql.Tx, username, displayName, pass
 			return entity.User{}, repository.ErrUniqueViolation
 		}
 	}
-	r.users[user.ID.String()] = user
+	r.users[user.ID] = user
 
 	return user, nil
 }
@@ -117,19 +117,19 @@ func (r *fakeUsersRepository) UserByUsername(tx *sql.Tx, username string) (entit
 	return entity.User{}, repository.ErrRecordNotFound
 }
 
-func (r *fakeUsersRepository) LikePost(tx *sql.Tx, userID string, postID uuid.UUID) error {
+func (r *fakeUsersRepository) LikePost(tx *sql.Tx, userID, postID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if err, ok := r.errors["LikePost"]; ok {
 		return err
 	}
-	r.likes[userID] = append(r.likes[userID], postID.String())
+	r.likes[userID] = append(r.likes[userID], postID)
 
 	return nil
 }
 
-func (r *fakeUsersRepository) UnlikePost(tx *sql.Tx, userID string, postID string) error {
+func (r *fakeUsersRepository) UnlikePost(tx *sql.Tx, userID, postID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/go/internal/infrastructure/injector.go
+++ b/go/internal/infrastructure/injector.go
@@ -16,7 +16,7 @@ func InjectUsersRepository(db *sql.DB) repository.UsersRepository {
 	return persistence.NewUsersRepository(db)
 }
 
-func InjecttimelineItemsRepository(db *sql.DB) repository.TimelineItemsRepository {
+func InjectTimelineItemsRepository(db *sql.DB) repository.TimelineItemsRepository {
 	if testing.Testing() {
 		return fake.NewFakeTimelineItemsRepository()
 	}

--- a/go/internal/infrastructure/persistence/timeline_items.go
+++ b/go/internal/infrastructure/persistence/timeline_items.go
@@ -7,8 +7,6 @@ import (
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/repository"
 	"x-clone-backend/internal/domain/value"
-
-	"github.com/google/uuid"
 )
 
 type timelineItemsRepository struct {
@@ -31,9 +29,9 @@ func (r *timelineItemsRepository) SpecificUserPosts(userID string) ([]*entity.Ti
 	var timelineitems []*entity.TimelineItem
 	for rows.Next() {
 		var (
-			id             uuid.UUID
+			id             string
 			postType       string
-			author_id      uuid.UUID
+			author_id      string
 			parent_post_id value.NullUUID
 			text           string
 			created_at     time.Time
@@ -76,9 +74,9 @@ func (r *timelineItemsRepository) UserAndFolloweePosts(userID string) ([]*entity
 	var timelineitems []*entity.TimelineItem
 	for rows.Next() {
 		var (
-			id             uuid.UUID
+			id             string
 			postType       string
-			author_id      uuid.UUID
+			author_id      string
 			parent_post_id value.NullUUID
 			text           string
 			created_at     time.Time
@@ -102,17 +100,17 @@ func (r *timelineItemsRepository) UserAndFolloweePosts(userID string) ([]*entity
 }
 
 // CreatePost creates and returns a new post by the given userID with the provided text.
-func (r *timelineItemsRepository) CreatePost(userID uuid.UUID, text string) (entity.TimelineItem, error) {
+func (r *timelineItemsRepository) CreatePost(userID, text string) (entity.TimelineItem, error) {
 	query := `INSERT INTO timelineitems (type, author_id, text) VALUES ($1, $2, $3) RETURNING id, created_at`
 
 	var (
-		id        uuid.UUID
+		id        string
 		createdAt time.Time
 	)
 
 	postType := entity.PostTypePost
 
-	err := r.db.QueryRow(query, postType, userID.String(), text).Scan(&id, &createdAt)
+	err := r.db.QueryRow(query, postType, userID, text).Scan(&id, &createdAt)
 	if err != nil {
 		if IsForeignKeyError(err) {
 			return entity.TimelineItem{}, repository.ErrForeignViolation

--- a/go/internal/infrastructure/persistence/users.go
+++ b/go/internal/infrastructure/persistence/users.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/uuid"
-
 	"x-clone-backend/internal/domain/entity"
 	"x-clone-backend/internal/domain/repository"
 )
@@ -47,7 +45,7 @@ func (r *usersRepository) CreateUser(tx *sql.Tx, username, displayName, password
         RETURNING id, created_at, updated_at`
 
 	var (
-		id                   uuid.UUID
+		id                   string
 		createdAt, updatedAt time.Time
 	)
 
@@ -155,7 +153,7 @@ func (r *usersRepository) UserByUsername(tx *sql.Tx, username string) (entity.Us
 	return user, err
 }
 
-func (r *usersRepository) LikePost(tx *sql.Tx, userID string, postID uuid.UUID) error {
+func (r *usersRepository) LikePost(tx *sql.Tx, userID string, postID string) error {
 	query := "INSERT INTO likes (user_id, post_id) VALUES ($1, $2)"
 
 	var err error
@@ -240,12 +238,12 @@ func (r *usersRepository) Followees(tx *sql.Tx, targetUserID string) ([]string, 
 
 	var ids []string
 	for rows.Next() {
-		var id uuid.UUID
+		var id string
 		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}
 
-		ids = append(ids, id.String())
+		ids = append(ids, id)
 	}
 
 	return ids, err

--- a/go/internal/openapi/models.gen.go
+++ b/go/internal/openapi/models.gen.go
@@ -5,8 +5,6 @@ package openapi
 
 import (
 	"time"
-
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 const (
@@ -37,11 +35,11 @@ type CreatePostRequest struct {
 
 // CreatePostResponse Response when creating a timeline item.
 type CreatePostResponse struct {
-	AuthorId  openapi_types.UUID `json:"authorId"`
-	CreatedAt time.Time          `json:"createdAt"`
-	Id        openapi_types.UUID `json:"id"`
-	Text      string             `json:"text"`
-	Type      string             `json:"type"`
+	AuthorId  string    `json:"authorId"`
+	CreatedAt time.Time `json:"createdAt"`
+	Id        string    `json:"id"`
+	Text      string    `json:"text"`
+	Type      string    `json:"type"`
 }
 
 // CreateQuoteRepostRequest defines model for create_quote_repost_request.
@@ -157,13 +155,13 @@ type LoginResponse struct {
 
 // User defines model for user.
 type User struct {
-	Bio         string             `json:"bio"`
-	CreatedAt   time.Time          `json:"createdAt"`
-	DisplayName string             `json:"displayName"`
-	Id          openapi_types.UUID `json:"id"`
-	IsPrivate   bool               `json:"isPrivate"`
-	UpdatedAt   time.Time          `json:"updatedAt"`
-	Username    string             `json:"username"`
+	Bio         string    `json:"bio"`
+	CreatedAt   time.Time `json:"createdAt"`
+	DisplayName string    `json:"displayName"`
+	Id          string    `json:"id"`
+	IsPrivate   bool      `json:"isPrivate"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	Username    string    `json:"username"`
 }
 
 // VerifySessionResponse defines model for verify_session_response.

--- a/go/internal/openapi/server.gen.go
+++ b/go/internal/openapi/server.gen.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 
 	"github.com/oapi-codegen/runtime"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // ServerInterface represents all server handlers.
@@ -33,7 +32,7 @@ type ServerInterface interface {
 	GetUserPostsTimeline(w http.ResponseWriter, r *http.Request, id string)
 	// Creates a new post.
 	// (POST /users/{id}/posts)
-	CreatePost(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	CreatePost(w http.ResponseWriter, r *http.Request, id string)
 	// Creates a new quote repost.
 	// (POST /users/{id}/quote_reposts)
 	CreateQuoteRepost(w http.ResponseWriter, r *http.Request, id string)
@@ -164,7 +163,7 @@ func (siw *ServerInterfaceWrapper) CreatePost(w http.ResponseWriter, r *http.Req
 	var err error
 
 	// ------------- Path parameter "id" -------------
-	var id openapi_types.UUID
+	var id string
 
 	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {

--- a/openapi/components/responses/create_post_response.yml
+++ b/openapi/components/responses/create_post_response.yml
@@ -12,10 +12,8 @@ properties:
     type: string
   id:
     type: string
-    format: uuid
   authorId:
     type: string
-    format: uuid
   text:
     type: string
   createdAt:

--- a/openapi/components/schemas/user.yml
+++ b/openapi/components/schemas/user.yml
@@ -11,7 +11,6 @@ required:
 properties:
   id:
     type: string
-    format: uuid
   username:
     type: string
   displayName:

--- a/openapi/paths/user_posts.yml
+++ b/openapi/paths/user_posts.yml
@@ -28,7 +28,6 @@ post:
     name: id
     schema:
       type: string
-      format: uuid
     required: true
   operationId: CreatePost
   requestBody:


### PR DESCRIPTION
## Issue Number
#726 

## Implementation Summary
This PR changes the type of IDs, such as user IDs and post IDs, from `uuid.UUID` to `string` in the application code. Managing IDs as `uuid.UUID` introduced several complexities. For example, frequent conversions between `uuid.UUID` and `string` were required, particularly when interacting with systems like Redis that expect string keys.

Initially, I considered changing the database column types from `UUID` to `char(36)` and generating random UUIDs within the application before inserting data. However, I decided against it for the following reasons:

1. PostgreSQL and its driver (`pgx`) can automatically cast `UUID` to `string`, reducing the need for schema changes.
2. Changing the type of ID columns would have a big impact due to the many foreign key constraints dependent on them.

As a result, while IDs are now handled as `string` in the application code, the database continues to store and manage them as `UUID`.
 
## Scope of Impact
The change doesn't have any impact on the database and API schema.

## Particular points to check
If the change looks appropriate.

## Test
Nothing added.

## Schedule
#729 should be merged first due to the "k8s manifests test" issue.
