### PR TITLE
[TS] Fix API Endpoint Mismatch Preventing POST Creation

### DIFF
--- a/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
+++ b/ts/twitter/src/app/@modal/(.)compose/post/_components/post-modal/use-post-modal.ts
@@ -43,11 +43,11 @@ export const usePostModal = ({
     formData: FormData,
   ) => {
     try {
-      const res = await createPost({
-        // biome-ignore lint/style/noNonNullAssertion: user is guaranteed to exist in this context.
-        user_id: user!.id,
-        text: formData.get("text") as string,
-      });
+      // biome-ignore lint/style/noNonNullAssertion: user is guaranteed to exist in this context.
+      const userId = user!.id;
+      const text = formData.get("text") as string;
+
+      const res = await createPost(userId, { text });
 
       if (!res.ok) {
         return ERROR_MESSAGES.POST_CREATION_ERROR;

--- a/ts/twitter/src/lib/actions/__test__/create-post.test.ts
+++ b/ts/twitter/src/lib/actions/__test__/create-post.test.ts
@@ -2,14 +2,13 @@ import { STATUS_TEXT } from "@/lib/constants/error-messages";
 import { createPost } from "../create-post";
 
 describe("createPost API Tests", () => {
-  const API_ENDPOINT = `${process.env.API_BASE_URL}/api/posts`;
+  const mockUserId = "623f9799-e816-418b-9e5e-09ad043653fb";
+  const API_ENDPOINT = `${process.env.API_BASE_URL}/api/users/${mockUserId}/posts`;
+
   const mockFetch = vi.fn();
   vi.stubGlobal("fetch", mockFetch);
 
-  const request = {
-    user_id: "623f9799-e816-418b-9e5e-09ad043653fb",
-    text: "test post",
-  };
+  const text = "test post";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -20,8 +19,8 @@ describe("createPost API Tests", () => {
       // Arrange
       const response = {
         id: "91c76cd1-29c9-475a-abe3-247234bd9fd4",
-        user_id: request.user_id,
-        text: request.text,
+        user_id: mockUserId,
+        text: text,
         created_at: "2024-01-01T00:00:00Z",
       };
 
@@ -31,7 +30,7 @@ describe("createPost API Tests", () => {
       });
 
       // Act
-      const result = await createPost(request);
+      const result = await createPost(mockUserId, { text });
 
       // Assert
       expect(result).toEqual({ ok: true, value: response });
@@ -40,7 +39,7 @@ describe("createPost API Tests", () => {
         expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(request),
+          body: JSON.stringify({ text }),
         }),
       );
     });
@@ -58,7 +57,7 @@ describe("createPost API Tests", () => {
       mockFetch.mockResolvedValueOnce(response);
 
       // Act
-      const result = await createPost(request);
+      const result = await createPost(mockUserId, { text });
 
       // Assert
       expect(result).toEqual({
@@ -76,7 +75,9 @@ describe("createPost API Tests", () => {
       mockFetch.mockRejectedValueOnce(new Error(errorMessage));
 
       // Act & Assert
-      await expect(createPost(request)).rejects.toThrow(errorMessage);
+      await expect(createPost(mockUserId, { text })).rejects.toThrow(
+        errorMessage,
+      );
     });
   });
 });

--- a/ts/twitter/src/lib/actions/create-post.ts
+++ b/ts/twitter/src/lib/actions/create-post.ts
@@ -8,7 +8,6 @@ import {
 } from "./types";
 
 interface CreatePostBody {
-  user_id: string;
   text: string;
 }
 
@@ -20,16 +19,17 @@ interface CreatePostResponse {
 }
 
 export async function createPost(
+  userId: string,
   body: CreatePostBody,
 ): Promise<ServerActionsResult<CreatePostResponse, ServerActionsError>> {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/posts`,
+    `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/users/${userId}/posts`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ text: body.text }),
     },
   );
 


### PR DESCRIPTION
## Issue Number
#737 

## Implementation Summary
We are currently experiencing an issue where we cannot create posts from the frontend. When attempting to do so, the response status is 404, and the error message is as follows.

![Image](https://github.com/user-attachments/assets/09ddd71a-c998-41e7-bb80-2bd6fe7cd23a)

After investigation, I've determined that the issue stems from a mismatch between the endpoint URL used in the frontend and the actual endpoint implemented on the backend. This problem appears to have been introduced by a [PR](https://github.com/okuda-seminar/Twitter-Clone/pull/736/files#diff-98407184f9f853cb5b36a5dc6a0f563a1b8acd5f25cc18d20682334451f355b3) that changed the backend endpoint from `m.HandleFunc("POST "+options.BaseURL+"/api/posts", wrapper.CreatePost)` to `m.HandleFunc("POST "+options.BaseURL+"/users/{id}/posts", wrapper.CreatePost)`. However, the frontend server action is still using `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/posts`.

To fix this issue, I have updated the create-post.ts server action to use the correct endpoint URL.

## Scope of Impact
Post creation functionality on the frontend.

## Particular points to check
Is the server action modification correct?

## Test
Verify that post creation works as follows.

https://github.com/user-attachments/assets/9d0ebd49-0153-4878-83f3-8341aaa0efc1

## Schedule
5/24
