### PR TITLE
[TS] Make Signup text clickable to redirect to signup page in login modal

### DIFF
--- a/ts/twitter/src/app/(public)/login/_components/account-modal.tsx
+++ b/ts/twitter/src/app/(public)/login/_components/account-modal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { AppleIcon, GoogleIcon } from "@/lib/components/icons";
+import { AppleIcon, GoogleIcon, XIcon } from "@/lib/components/icons";
 import { useColorModeValue } from "@/lib/components/ui/color-mode";
-import { Box, Button, Input, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, IconButton, Input, Text, VStack } from "@chakra-ui/react";
+import { Link as ChakraLink } from "@chakra-ui/react";
+import NextLink from "next/link";
 import type React from "react";
 
 interface AccountModalProps {
@@ -23,9 +25,18 @@ export const AccountModal: React.FC<AccountModalProps> = ({
 
   return (
     <VStack as="form" gap={4} onSubmit={handleNext}>
-      <VStack gap={4} align="stretch" width="100%">
-        <Text fontSize="2xl" fontWeight="bold" textAlign="center">
-          Login to X
+      <IconButton
+        aria-label="X"
+        width="36px"
+        color={useColorModeValue("black", "white")}
+        bg={useColorModeValue("white", "black")}
+        mt={-4}
+      >
+        <XIcon boxSize={8} />
+      </IconButton>
+      <VStack gap={8} align="stretch" width="55%">
+        <Text fontSize="3xl" fontWeight="bold" textAlign="left">
+          Sign in to X
         </Text>
         <Button
           width="100%"
@@ -48,7 +59,7 @@ export const AccountModal: React.FC<AccountModalProps> = ({
           <AppleIcon /> Login with Apple
         </Button>
       </VStack>
-      <Box position="relative" width="100%" my={2}>
+      <Box position="relative" width="55%" my={2}>
         <Box borderBottom="2px solid" borderColor="gray" width="100%" />
         <Box
           position="absolute"
@@ -64,7 +75,7 @@ export const AccountModal: React.FC<AccountModalProps> = ({
         </Box>
       </Box>
 
-      <VStack gap={4} align="stretch" width="100%">
+      <VStack gap={8} align="stretch" width="55%">
         <Input
           placeholder="Phone, email or username"
           value={username}
@@ -89,24 +100,31 @@ export const AccountModal: React.FC<AccountModalProps> = ({
         >
           Next
         </Button>
-        <Text
-          textAlign="center"
-          color="blue.primary"
-          cursor="pointer"
-          _hover={{ textDecoration: "underline" }}
+        <Button
+          type="submit"
+          width="100%"
+          bg={useColorModeValue("white", "black")}
+          color={useColorModeValue("black", "white")}
+          borderRadius="full"
+          fontWeight="bold"
+          boxShadow="0 0 0 1px gray"
         >
-          Forgot your password?
-        </Text>
-        <Text textAlign="center" color="gray">
+          Forgot password?
+        </Button>
+        <Text textAlign="left" color="gray">
           Don't have an account?&nbsp;
-          <Text
-            as="span"
-            color="blue.primary"
-            cursor="pointer"
-            _hover={{ textDecoration: "underline" }}
-          >
-            Sign up
-          </Text>
+          <ChakraLink asChild>
+            <NextLink href="/signup">
+              <Text
+                as="span"
+                color="blue.primary"
+                cursor="pointer"
+                _hover={{ textDecoration: "underline" }}
+              >
+                Sign up
+              </Text>
+            </NextLink>
+          </ChakraLink>
         </Text>
       </VStack>
     </VStack>

--- a/ts/twitter/src/app/(public)/login/_components/login-modal.stories.tsx
+++ b/ts/twitter/src/app/(public)/login/_components/login-modal.stories.tsx
@@ -18,7 +18,7 @@ export const AccountForm: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText("Login to X")).toBeInTheDocument();
+    expect(canvas.getByText("Sign in to X")).toBeInTheDocument();
 
     const usernameInput = canvas.getByPlaceholderText(
       "Phone, email or username",
@@ -63,7 +63,7 @@ export const PasswordForm: Story = {
     const passwordInput = canvas.getByPlaceholderText("Password");
     await userEvent.type(passwordInput, "swweeweerd");
 
-    const loginButton = canvas.getByRole("button", { name: "Login" });
+    const loginButton = canvas.getByRole("button", { name: "Log in" });
     expect(loginButton).not.toBeDisabled();
   },
 };
@@ -93,7 +93,7 @@ export const LoginFailed: Story = {
     const passwordInput = canvas.getByPlaceholderText("Password");
     await userEvent.type(passwordInput, "ssdsdwdwee");
 
-    const loginButton = canvas.getByRole("button", { name: "Login" });
+    const loginButton = canvas.getByRole("button", { name: "Log in" });
     await userEvent.click(loginButton);
 
     await expect(
@@ -124,7 +124,7 @@ export const NetworkError: Story = {
     const passwordInput = canvas.getByPlaceholderText("Password");
     await userEvent.type(passwordInput, "ssdsdwdedw");
 
-    const loginButton = canvas.getByRole("button", { name: "Login" });
+    const loginButton = canvas.getByRole("button", { name: "Log in" });
     await userEvent.click(loginButton);
 
     await expect(
@@ -150,6 +150,6 @@ export const BackNavigation: Story = {
     const backButton = canvas.getByRole("button", { name: "Back to account" });
     await userEvent.click(backButton);
 
-    expect(canvas.getByText("Login to X")).toBeInTheDocument();
+    expect(canvas.getByText("Sign in to X")).toBeInTheDocument();
   },
 };

--- a/ts/twitter/src/app/(public)/login/_components/login-modal.tsx
+++ b/ts/twitter/src/app/(public)/login/_components/login-modal.tsx
@@ -34,9 +34,10 @@ export const LoginModal: React.FC = () => {
   return (
     <Flex align="center" justify="center" minH="100vh">
       <Box
-        width="400px"
+        width="600px"
+        height="650px"
         bg={useColorModeValue("white", "black")}
-        borderRadius="md"
+        borderRadius="2xl"
         p={6}
         color={useColorModeValue("black", "white")}
         border="1px solid gray"

--- a/ts/twitter/src/app/(public)/login/_components/password-modal.tsx
+++ b/ts/twitter/src/app/(public)/login/_components/password-modal.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import type { LoginBody } from "@/lib/actions/login";
-import { BackIcon } from "@/lib/components/icons";
+import { BackIcon, XIcon } from "@/lib/components/icons";
 import { useColorModeValue } from "@/lib/components/ui/color-mode";
-import { Box, Button, Input, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, IconButton, Input, Text, VStack } from "@chakra-ui/react";
+import { Link as ChakraLink } from "@chakra-ui/react";
+import NextLink from "next/link";
 import { useActionState } from "react";
 import { usePasswordModal } from "./use-password-modal";
 
@@ -22,99 +24,135 @@ export const PasswordModal: React.FC<PasswordModalProps> = ({
   const [message, formAction] = useActionState(handleLoginAction, undefined);
 
   return (
-    <form action={formAction}>
-      <VStack gap={4}>
-        <Box width="100%" position="relative" mb={4}>
+    <Box position="relative" height="100%" minHeight="500px">
+      <form action={formAction}>
+        <Box width="100%" position="relative" mb={2}>
           <Button
             variant="ghost"
-            size="sm"
+            size="md"
             onClick={handleBackButtonClick}
             position="absolute"
-            left={0}
-            top={0}
-            _hover={{ color: "white" }}
+            left={-4}
+            top={-6}
+            _hover={{ color: useColorModeValue("black", "white") }}
             aria-label="Back to account"
           >
             <BackIcon /> Back
           </Button>
         </Box>
+        <VStack align="center" height="100%">
+          <VStack gap={8} align="stretch" width="80%">
+            <IconButton
+              aria-label="X"
+              width="36px"
+              alignSelf="center"
+              color={useColorModeValue("black", "white")}
+              bg={useColorModeValue("white", "black")}
+              mt={-6}
+            >
+              <XIcon boxSize={8} />
+            </IconButton>
 
-        <Text fontSize="2xl" fontWeight="bold" textAlign="center">
-          Enter your password
-        </Text>
+            <Text fontSize="3xl" fontWeight="bold" textAlign="left">
+              Enter your password
+            </Text>
 
-        {message !== undefined && (
-          <Text
-            fontSize="14px"
-            lineHeight="16px"
-            px="16px"
-            py="12px"
-            bg="error.primary"
-            borderRadius="8px"
-            color="white"
+            {message !== undefined && (
+              <Text
+                fontSize="14px"
+                lineHeight="16px"
+                px="16px"
+                py="12px"
+                bg="error.primary"
+                borderRadius="8px"
+                color="white"
+              >
+                {message}
+              </Text>
+            )}
+
+            {/* TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/760 
+            - Implement floating label behavior for email and password inputs in password modal. */}
+            <Input
+              name="username"
+              value={loginFormValue.username}
+              readOnly
+              bg={useColorModeValue("gray.100", "gray.900")}
+              color={useColorModeValue("black", "gray.500")}
+              pl="2"
+              width="100%"
+              height="50px"
+              _placeholder={{ color: "gray" }}
+              _focus={{ borderColor: "blue.primary" }}
+            />
+
+            <Input
+              name="password"
+              placeholder="Password"
+              type="password"
+              value={loginFormValue.password}
+              onChange={(e) => handlePasswordChange(e.target.value)}
+              bg={useColorModeValue("gray.100", "black")}
+              color={useColorModeValue("black", "white")}
+              borderColor={useColorModeValue("gray.200", "gray")}
+              pl="2"
+              width="100%"
+              height="50px"
+              _placeholder={{ color: "gray" }}
+              _focus={{ borderColor: "blue.primary" }}
+            />
+
+            <Text
+              color={"blue.primary"}
+              fontSize="sm"
+              textAlign="left"
+              width="100%"
+              mt="-30px"
+              cursor="pointer"
+              _hover={{ textDecoration: "underline" }}
+            >
+              Forgot password?
+            </Text>
+          </VStack>
+          <VStack
+            gap={4}
+            align="stretch"
+            width="80%"
+            position="absolute"
+            bottom="20px"
           >
-            {message}
-          </Text>
-        )}
+            <Button
+              type="submit"
+              width="100%"
+              height="50px"
+              bg={useColorModeValue("black", "white")}
+              color={useColorModeValue("white", "black")}
+              borderRadius="full"
+              fontWeight="bold"
+              fontSize="md"
+              disabled={loginFormValue.password.trim() === ""}
+            >
+              Log in
+            </Button>
 
-        <Input
-          name="username"
-          value={loginFormValue.username}
-          readOnly
-          bg={useColorModeValue("gray.100", "gray.900")}
-          color={useColorModeValue("black", "gray.500")}
-          pl="2"
-          _placeholder={{ color: "gray" }}
-          _focus={{ borderColor: "blue.primary" }}
-        />
-
-        <Input
-          name="password"
-          placeholder="Password"
-          type="password"
-          value={loginFormValue.password}
-          onChange={(e) => handlePasswordChange(e.target.value)}
-          bg={useColorModeValue("gray.100", "black")}
-          color={useColorModeValue("black", "white")}
-          borderColor={useColorModeValue("gray.200", "gray")}
-          pl="2"
-          _placeholder={{ color: "gray" }}
-          _focus={{ borderColor: "blue.primary" }}
-        />
-
-        <Text
-          color={"blue.primary"}
-          textAlign="center"
-          cursor="pointer"
-          _hover={{ textDecoration: "underline" }}
-        >
-          Forgot your password?
-        </Text>
-
-        <Button
-          type="submit"
-          width="100%"
-          bg={useColorModeValue("black", "white")}
-          color={useColorModeValue("white", "black")}
-          borderRadius="full"
-          fontWeight="bold"
-          disabled={loginFormValue.password.trim() === ""}
-        >
-          Login
-        </Button>
-
-        <Text textAlign="center" color="gray">
-          Don't have an account?&nbsp;
-          <Text
-            as="span"
-            color="blue.primary"
-            cursor="pointer"
-            _hover={{ textDecoration: "underline" }}
-          >
-            Sign up
-          </Text>
-        </Text>
-      </VStack>
-    </form>
+            <Text textAlign="left" color="gray">
+              Don't have an account?&nbsp;
+              <ChakraLink asChild>
+                <NextLink href="/signup">
+                  <Text
+                    as="span"
+                    color="blue.primary"
+                    cursor="pointer"
+                    _hover={{ textDecoration: "underline" }}
+                  >
+                    Sign up
+                  </Text>
+                </NextLink>
+              </ChakraLink>
+            </Text>
+          </VStack>
+        </VStack>
+      </form>
+    </Box>
   );
 };

--- a/ts/twitter/src/app/(public)/signup/_components/signup-modal.tsx
+++ b/ts/twitter/src/app/(public)/signup/_components/signup-modal.tsx
@@ -29,6 +29,8 @@ export const SignupModal: React.FC = () => {
   const [message, formAction] = useActionState(handleSignupAction, undefined);
 
   return (
+    // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/759
+    // - Fix Sign Up Modal UI Layout and Styling.
     <Dialog.Root open={true} placement="center">
       <Dialog.Backdrop />
       <Dialog.Content


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/758

## Implementation Summary
I added a Link tag to the signup text in the login modal to navigate to /signup. I also modified the UI of the login modal and password modal.

## Particular points to check
Please verify that:

You can navigate to /signup
There are no differences between the original X and the product UI

## Test
Nothing added.

## Schedule
6/20