### PR TITLE
[TS] Add middleware to handle redirect decisions

### DIFF
--- a/ts/twitter/.env.test
+++ b/ts/twitter/.env.test
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_LOCAL_API_BASE_URL=http://localhost:80
+VITE_FRONTEND_URL=http://localhost:3000

--- a/ts/twitter/src/__test__/middleware.test.ts
+++ b/ts/twitter/src/__test__/middleware.test.ts
@@ -1,0 +1,84 @@
+import { AUTH_COOKIE_OPTIONS } from "@/lib/constants/cookie-constants";
+import { type NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { middleware } from "../middleware";
+// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/769
+// - Add E2E tests for actual access control behavior.
+vi.mock("next/server", () => ({
+  NextRequest: vi.fn(),
+  NextResponse: {
+    next: vi.fn(() => ({ type: "next" })),
+    redirect: vi.fn((url: URL) => ({ type: "redirect", url: url.toString() })),
+  },
+}));
+
+describe("middleware", () => {
+  const BASE_URL = process.env.VITE_FRONTEND_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createMockRequest = (pathname: string, authToken?: string) => {
+    const url = new URL(pathname, BASE_URL);
+    const mockRequest = {
+      nextUrl: url,
+      url: url.toString(),
+      cookies: {
+        get: (name: string) => {
+          if (name === AUTH_COOKIE_OPTIONS.name && authToken) {
+            return { name, value: authToken };
+          }
+          return undefined;
+        },
+      },
+    } as NextRequest;
+    return mockRequest;
+  };
+
+  describe("Rule 1: Unauthenticated user accessing protected route → Redirect to login", () => {
+    it("should redirect unauthenticated users from protected routes", () => {
+      const request = createMockRequest("/home");
+      const response = middleware(request);
+
+      expect(response.type).toBe("redirect");
+      expect(response.url).toBe(`${BASE_URL}/login`);
+    });
+  });
+
+  describe("Rule 2: Authenticated user accessing public route → Redirect to home", () => {
+    it("should redirect authenticated users from login page", () => {
+      const request = createMockRequest("/login", "any-token");
+      const response = middleware(request);
+
+      expect(response.type).toBe("redirect");
+      expect(response.url).toBe(`${BASE_URL}/home`);
+    });
+
+    it("should redirect authenticated users from signup page", () => {
+      const request = createMockRequest("/signup", "any-token");
+      const response = middleware(request);
+
+      expect(response.type).toBe("redirect");
+      expect(response.url).toBe(`${BASE_URL}/home`);
+    });
+  });
+
+  describe("Rule 3: All other cases → Continue to the requested page", () => {
+    it("should allow unauthenticated access to public routes", () => {
+      const request = createMockRequest("/login");
+      const response = middleware(request);
+
+      expect(response).toEqual({ type: "next" });
+      expect(NextResponse.redirect).not.toHaveBeenCalled();
+    });
+
+    it("should allow authenticated access to protected routes", () => {
+      const request = createMockRequest("/home", "any-token");
+      const response = middleware(request);
+
+      expect(response).toEqual({ type: "next" });
+      expect(NextResponse.redirect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ts/twitter/src/app/(protected)/layout.tsx
+++ b/ts/twitter/src/app/(protected)/layout.tsx
@@ -10,9 +10,6 @@ export default async function ProtectedLayout({
   children: React.ReactNode;
   modal: React.ReactNode;
 }>) {
-  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/733
-  // - Add middleware to handle redirect decisions.
-  // But checking whether a user is authenticated in the layout is required.
   const result = await verifySession();
   if (!result.ok) {
     redirect("/login");

--- a/ts/twitter/src/app/(public)/layout.tsx
+++ b/ts/twitter/src/app/(public)/layout.tsx
@@ -6,9 +6,6 @@ export default async function PublicLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/733
-  // - Add middleware to handle redirect decisions.
-  // But checking whether a user is authenticated in the layout is required.
   const result = await verifySession();
   if (result.ok) {
     redirect("/");

--- a/ts/twitter/src/lib/actions/__test__/create-post.test.ts
+++ b/ts/twitter/src/lib/actions/__test__/create-post.test.ts
@@ -3,7 +3,7 @@ import { createPost } from "../create-post";
 
 describe("createPost API Tests", () => {
   const mockUserId = "623f9799-e816-418b-9e5e-09ad043653fb";
-  const API_ENDPOINT = `${process.env.API_BASE_URL}/api/users/${mockUserId}/posts`;
+  const API_ENDPOINT = `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/users/${mockUserId}/posts`;
 
   const mockFetch = vi.fn();
   vi.stubGlobal("fetch", mockFetch);

--- a/ts/twitter/src/lib/actions/__test__/find-user-by-id.test.ts
+++ b/ts/twitter/src/lib/actions/__test__/find-user-by-id.test.ts
@@ -9,7 +9,7 @@ describe("findUserById API Tests", () => {
     user_id: "623f9799-e816-418b-9e5e-09ad043653fb",
   };
 
-  const API_ENDPOINT = `${process.env.API_BASE_URL}/api/users/${request.user_id}`;
+  const API_ENDPOINT = `${process.env.NEXT_PUBLIC_LOCAL_API_BASE_URL}/api/users/${request.user_id}`;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/ts/twitter/src/middleware.ts
+++ b/ts/twitter/src/middleware.ts
@@ -1,0 +1,40 @@
+import { AUTH_COOKIE_OPTIONS } from "@/lib/constants/cookie-constants";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_ROUTES = {
+  login: "/login",
+  signup: "/signup",
+};
+
+const HOME_ROUTE = "/home";
+
+export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const authToken = request.cookies.get(AUTH_COOKIE_OPTIONS.name)?.value;
+
+  const isPublicRoute = Object.values(PUBLIC_ROUTES).some(
+    (route) => pathname === route,
+  );
+
+  const hasAuthToken = !!authToken;
+
+  // Rule 1: Unauthenticated user accessing protected route → Redirect to login.
+  if (!hasAuthToken && !isPublicRoute) {
+    const loginUrl = new URL(PUBLIC_ROUTES.login, request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Rule 2: Authenticated user accessing public route → Redirect to home.
+  if (hasAuthToken && isPublicRoute) {
+    const homeUrl = new URL(HOME_ROUTE, request.url);
+    return NextResponse.redirect(homeUrl);
+  }
+
+  // Rule 3: All other cases → Continue to the requested page.
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|robots.txt).*)"],
+};

--- a/ts/twitter/vitest.setup.ts
+++ b/ts/twitter/vitest.setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom";
+import { loadEnvConfig } from "@next/env";
+
+const projectDir = process.cwd();
+loadEnvConfig(projectDir);


### PR DESCRIPTION
## Issue Number
#733 
#763 

## Implementation Summary
Currently, redirect logic is handled in layout.tsx. To improve the architecture for future scalability, I've introduced Next.js middleware. Additionally, this PR resolves issue #763 by implementing proper environment variable mocking in tests.

## Scope of Impact
Currently performing duplicate redirect checks - once in middleware and again in both protected and public layout.tsx files.

## Particular points to check

- Correctness of middleware test implementation
- Proper middleware integration approach
- Accuracy of middleware behavior
- Correct handling of environment variables in server actions

## Test
Run the following commands to verify:
```
npm run test
```
Additionally, temporarily modify layout.tsx to verify middleware is functioning correctly.

Finally, verify that the URL is displayed as follows during action tests:
<img width="976" alt="Screenshot 2025-06-17 at 11 38 11" src="https://github.com/user-attachments/assets/fdd23c5c-9e3d-45bf-b28a-5a0e7aab9752" />


## Schedule
6/21
