### PR TITLE
[Go] Refactor DeletePost and DeleteRepost

### DIFF
--- a/go/internal/application/usecase/api/delete_post.go
+++ b/go/internal/application/usecase/api/delete_post.go
@@ -1,0 +1,10 @@
+package api
+
+import "x-clone-backend/internal/domain/entity"
+
+type DeletePostUsecase interface {
+	DeletePost(postID string) (entity.TimelineItem, error)
+
+	SetError(err error)
+	ClearError()
+}

--- a/go/internal/application/usecase/api/delete_repost.go
+++ b/go/internal/application/usecase/api/delete_repost.go
@@ -1,0 +1,10 @@
+package api
+
+import "x-clone-backend/internal/domain/entity"
+
+type DeleteRepostUsecase interface {
+	DeleteRepost(repostID string) (entity.TimelineItem, error)
+
+	SetError(err error)
+	ClearError()
+}

--- a/go/internal/application/usecase/fake/delete_post.go
+++ b/go/internal/application/usecase/fake/delete_post.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/domain/entity"
+)
+
+type fakeDeletePostUsecase struct {
+	err error
+}
+
+func NewFakeDeletePostUsecase() usecase.DeletePostUsecase {
+	return &fakeDeletePostUsecase{
+		err: nil,
+	}
+}
+
+func (u *fakeDeletePostUsecase) DeletePost(postID string) (entity.TimelineItem, error) {
+	return entity.TimelineItem{}, u.err
+}
+
+func (u *fakeDeletePostUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeDeletePostUsecase) ClearError() {
+	u.err = nil
+}

--- a/go/internal/application/usecase/fake/delete_repost.go
+++ b/go/internal/application/usecase/fake/delete_repost.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/domain/entity"
+)
+
+type fakeDeleteRepostUsecase struct {
+	err error
+}
+
+func NewFakeDeleteRepostUsecase() usecase.DeleteRepostUsecase {
+	return &fakeDeleteRepostUsecase{
+		err: nil,
+	}
+}
+
+func (u *fakeDeleteRepostUsecase) DeleteRepost(repostID string) (entity.TimelineItem, error) {
+	return entity.TimelineItem{}, u.err
+}
+
+func (u *fakeDeleteRepostUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeDeleteRepostUsecase) ClearError() {
+	u.err = nil
+}

--- a/go/internal/application/usecase/implementation/delete_post.go
+++ b/go/internal/application/usecase/implementation/delete_post.go
@@ -1,0 +1,24 @@
+package implementation
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+)
+
+type deletePostUsecase struct {
+	timelineItemsRepository repository.TimelineItemsRepository
+}
+
+func NewDeletePostUsecase(timelineItemsRepository repository.TimelineItemsRepository) usecase.DeletePostUsecase {
+	return &deletePostUsecase{
+		timelineItemsRepository,
+	}
+}
+
+func (u *deletePostUsecase) DeletePost(postID string) (entity.TimelineItem, error) {
+	return u.timelineItemsRepository.DeletePost(postID)
+}
+
+func (u *deletePostUsecase) SetError(err error) {}
+func (u *deletePostUsecase) ClearError()        {}

--- a/go/internal/application/usecase/implementation/delete_repost.go
+++ b/go/internal/application/usecase/implementation/delete_repost.go
@@ -1,0 +1,24 @@
+package implementation
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/domain/entity"
+	"x-clone-backend/internal/domain/repository"
+)
+
+type deleteRepostUsecase struct {
+	timelineItemsRepository repository.TimelineItemsRepository
+}
+
+func NewDeleteRepostUsecase(timelineItemsRepository repository.TimelineItemsRepository) usecase.DeleteRepostUsecase {
+	return &deleteRepostUsecase{
+		timelineItemsRepository,
+	}
+}
+
+func (u *deleteRepostUsecase) DeleteRepost(repostID string) (entity.TimelineItem, error) {
+	return u.timelineItemsRepository.DeleteRepost(repostID)
+}
+
+func (u *deleteRepostUsecase) SetError(err error) {}
+func (u *deleteRepostUsecase) ClearError()        {}

--- a/go/internal/application/usecase/injector/delete_post.go
+++ b/go/internal/application/usecase/injector/delete_post.go
@@ -1,0 +1,17 @@
+package injector
+
+import (
+	"testing"
+
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
+	"x-clone-backend/internal/application/usecase/implementation"
+	"x-clone-backend/internal/domain/repository"
+)
+
+func InjectDeletePostUsecase(timelineItemsRepository repository.TimelineItemsRepository) usecase.DeletePostUsecase {
+	if testing.Testing() {
+		return fake.NewFakeDeletePostUsecase()
+	}
+	return implementation.NewDeletePostUsecase(timelineItemsRepository)
+}

--- a/go/internal/application/usecase/injector/delete_repost.go
+++ b/go/internal/application/usecase/injector/delete_repost.go
@@ -1,0 +1,17 @@
+package injector
+
+import (
+	"testing"
+
+	"x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
+	"x-clone-backend/internal/application/usecase/implementation"
+	"x-clone-backend/internal/domain/repository"
+)
+
+func InjectDeleteRepostUsecase(timelineItemsRepository repository.TimelineItemsRepository) api.DeleteRepostUsecase {
+	if testing.Testing() {
+		return fake.NewFakeDeleteRepostUsecase()
+	}
+	return implementation.NewDeleteRepostUsecase(timelineItemsRepository)
+}

--- a/go/internal/controller/handler/delete_repost.go
+++ b/go/internal/controller/handler/delete_repost.go
@@ -1,28 +1,23 @@
 package handler
 
 import (
-	"database/sql"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"time"
 
 	usecase "x-clone-backend/internal/application/usecase/api"
 	"x-clone-backend/internal/domain/entity"
-	"x-clone-backend/internal/domain/value"
 	"x-clone-backend/internal/openapi"
 )
 
 type DeleteRepostHandler struct {
-	db                        *sql.DB
+	deleteRepostUsecase       usecase.DeleteRepostUsecase
 	updateNotificationUsecase usecase.UpdateNotificationUsecase
 }
 
-func NewDeleteRepostHandler(db *sql.DB, updateNotificationUsecase usecase.UpdateNotificationUsecase) DeleteRepostHandler {
+func NewDeleteRepostHandler(deleteRepostUsecase usecase.DeleteRepostUsecase, updateNotificationUsecase usecase.UpdateNotificationUsecase) DeleteRepostHandler {
 	return DeleteRepostHandler{
-		db:                        db,
-		updateNotificationUsecase: updateNotificationUsecase,
+		deleteRepostUsecase,
+		updateNotificationUsecase,
 	}
 }
 
@@ -34,39 +29,17 @@ func (h *DeleteRepostHandler) DeleteRepost(w http.ResponseWriter, r *http.Reques
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&body)
 	if err != nil {
-		http.Error(w, fmt.Sprintln("Request body was invalid."), http.StatusBadRequest)
+		http.Error(w, ErrInvalidRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
 
-	query := `DELETE FROM timelineitems WHERE id = $1 RETURNING type, text, created_at`
-
-	var (
-		postType  string
-		text      string
-		createdAt time.Time
-	)
-
-	err = h.db.QueryRow(query, body.RepostId).Scan(&postType, &text, &createdAt)
+	repost, err := h.deleteRepostUsecase.DeleteRepost(body.RepostId)
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			http.Error(w, fmt.Sprintf("No row found to delete: (repost id: %s)\n", body.RepostId), http.StatusNotFound)
-		default:
-			http.Error(w, fmt.Sprintf("Could not delete a repost: (repost id: %s)\n", body.RepostId), http.StatusInternalServerError)
-		}
+		http.Error(w, ErrDeleteRepostFailed.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	timelineitem := entity.TimelineItem{
-		Type:         postType,
-		ID:           body.RepostId,
-		AuthorID:     userID,
-		ParentPostID: value.NullUUID{UUID: parentID, Valid: true},
-		Text:         text,
-		CreatedAt:    createdAt,
-	}
-
-	go h.updateNotificationUsecase.SendNotification(userID, entity.RepostDeleted, &timelineitem)
+	go h.updateNotificationUsecase.SendNotification(userID, entity.RepostDeleted, &repost)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/controller/handler/errors.go
+++ b/go/internal/controller/handler/errors.go
@@ -20,6 +20,8 @@ var (
 	ErrRepostViolation      = errors.New("Could not repost a repost.")
 	ErrCreateRepost         = errors.New("Could not create a repost.")
 	ErrDeleteUserFailed     = errors.New("Could not delete a user.")
+	ErrDeletePostFailed     = errors.New("Could not delete a post.")
+	ErrDeleteRepostFailed   = errors.New("Could not delete a repost.")
 )
 
 func NewInvalidUserIDError(id string) error {

--- a/go/internal/controller/server.go
+++ b/go/internal/controller/server.go
@@ -49,6 +49,8 @@ func NewServer(db *sql.DB) Server {
 	createQuoteRepostUsecase := usecaseInjector.InjectCreateQuoteRepostUsecase(timelineItemsRepository)
 	createRepostUsecase := usecaseInjector.InjectCreateRepostUsecase(timelineItemsRepository)
 	createUserUsecase := usecaseInjector.InjectCreateUserUsecase(usersRepository)
+	deletePostUsecase := usecaseInjector.InjectDeletePostUsecase(timelineItemsRepository)
+	deleteRepostUsecase := usecaseInjector.InjectDeleteRepostUsecase(timelineItemsRepository)
 	deleteUserByIDUsecase := usecaseInjector.InjectDeleteUserByIDUsecase(usersRepository)
 	followUserUsecase := usecaseInjector.InjectFollowUserUsecase(usersRepository)
 	unfollowUserUsecase := usecaseInjector.InjectUnfollowUserUsecase(usersRepository)
@@ -70,10 +72,10 @@ func NewServer(db *sql.DB) Server {
 		FindUserByIDHandler:                        handler.NewFindUserByIDHandler(userByUserIDUsecase),
 		DeleteUserByIDHandler:                      handler.NewDeleteUserByIDHandler(deleteUserByIDUsecase),
 		CreatePostHandler:                          handler.NewCreatePostHandler(updateNotificationUsecase, createPostUsecase),
-		DeletePostHandler:                          handler.NewDeletePostHandler(db, updateNotificationUsecase),
+		DeletePostHandler:                          handler.NewDeletePostHandler(deletePostUsecase, updateNotificationUsecase),
 		CreateRepostHandler:                        handler.NewCreateRepostHandler(createRepostUsecase, updateNotificationUsecase),
 		CreateQuoteRepostHandler:                   handler.NewCreateQuoteRepostHandler(createQuoteRepostUsecase, updateNotificationUsecase),
-		DeleteRepostHandler:                        handler.NewDeleteRepostHandler(db, updateNotificationUsecase),
+		DeleteRepostHandler:                        handler.NewDeleteRepostHandler(deleteRepostUsecase, updateNotificationUsecase),
 		GetUserPostsTimelineHandler:                handler.NewGetUserPostsTimelineHandler(specificUserPostsUsecase),
 		GetReverseChronologicalHomeTimelineHandler: handler.NewGetReverseChronologicalHomeTimelineHandler(userAndFolloweePostsUsecase, updateNotificationUsecase, make(chan struct{}, 1)),
 		CreateFollowshipHandler:                    handler.NewCreateFollowshipHandler(followUserUsecase),

--- a/go/internal/domain/repository/timeline_items.go
+++ b/go/internal/domain/repository/timeline_items.go
@@ -8,9 +8,9 @@ type TimelineItemsRepository interface {
 	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
 	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
 	CreatePost(userID, text string) (entity.TimelineItem, error)
-	DeletePost(postID string) error
+	DeletePost(postID string) (entity.TimelineItem, error)
 	CreateRepost(userID, postID string) (entity.TimelineItem, error)
-	DeleteRepost(postID string) error
+	DeleteRepost(postID string) (entity.TimelineItem, error)
 	CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error)
 	TimelineItemByID(postID string) (*entity.TimelineItem, error)
 

--- a/go/internal/infrastructure/fake/timeline_items.go
+++ b/go/internal/infrastructure/fake/timeline_items.go
@@ -91,21 +91,22 @@ func (r *fakeTimelineitemsRepository) CreatePost(userID string, text string) (en
 	return timelineItem, nil
 }
 
-func (r *fakeTimelineitemsRepository) DeletePost(postID string) error {
+func (r *fakeTimelineitemsRepository) DeletePost(postID string) (entity.TimelineItem, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if err, ok := r.errors[repository.ErrKeyDeletePost]; ok {
-		return err
+		return entity.TimelineItem{}, err
 	}
 
-	if _, ok := r.timelineItems[postID]; !ok {
-		return repository.ErrRecordNotFound
+	post, ok := r.timelineItems[postID]
+	if !ok {
+		return entity.TimelineItem{}, repository.ErrRecordNotFound
 	}
 
 	delete(r.timelineItems, postID)
 
-	return nil
+	return *post, nil
 }
 
 func (r *fakeTimelineitemsRepository) CreateRepost(userID, postID string) (entity.TimelineItem, error) {
@@ -141,20 +142,22 @@ func (r *fakeTimelineitemsRepository) CreateRepost(userID, postID string) (entit
 	return timelineItem, nil
 }
 
-func (r *fakeTimelineitemsRepository) DeleteRepost(postID string) error {
+func (r *fakeTimelineitemsRepository) DeleteRepost(postID string) (entity.TimelineItem, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if err, ok := r.errors[repository.ErrKeyDeleteRepost]; ok {
-		return err
+		return entity.TimelineItem{}, err
 	}
 
-	if _, ok := r.timelineItems[postID]; !ok {
-		return repository.ErrRecordNotFound
+	repost, ok := r.timelineItems[postID]
+	if !ok {
+		return entity.TimelineItem{}, repository.ErrRecordNotFound
 	}
 
 	delete(r.timelineItems, postID)
-	return nil
+
+	return *repost, nil
 }
 
 func (r *fakeTimelineitemsRepository) CreateQuoteRepost(userID, postID, text string) (entity.TimelineItem, error) {


### PR DESCRIPTION
## Issue Number
#679 
#681 

## Implementation Summary
This PR refactors the `DeletePost` and `DeleteRepost` APIs by moving their core logic from the handler layer to the use case and repository layers.
Since `DeletePostUsecase` and `DeleteRepostUsecase` simply delegate to the repository, dedicated tests for them are not included in this PR.

## Scope of Impact
This refactoring does not change the behavior of the APIs.

## Particular points to check
Please verify that the APIs can be used properly by following the steps below:
1. Create a post:
```sh
curl --location 'localhost:80/api/users/<your user ID>/posts' \
--header 'Content-Type: application/json' \
--data '{
    "text": "test post"
}'
```
2. Create a repost:
```sh
curl --location 'localhost:80/api/users/<your user ID>/reposts' \
--header 'Content-Type: application/json' \
--data '{
    "post_id": "<the post ID>"
}'
```
3. Delete the repost:
```sh
curl --location --request DELETE 'localhost:80/api/users/<your user ID>/reposts/<the repost ID>` \
--header 'Content-Type: application/json' \
--data '{
    "repost_id": "<the repost ID>"
}'
```
4. Delete the post:
```sh
curl --location --request DELETE 'localhost:80/api/posts/<the post ID>'
```
## Test
`TestDeletePost` and `TestDeleteRepost` check if the handlers return the expected status code.

## Schedule
6/27
