### PR TITLE
[Go] Write tests in LikePost

### DIFF
--- a/go/internal/application/usecase/api/errors.go
+++ b/go/internal/application/usecase/api/errors.go
@@ -14,4 +14,6 @@ var (
 	ErrTokenGeneration      = errors.New("could not generate token")
 	ErrTooLongText          = errors.New("text is too long")
 	ErrRepostViolation      = errors.New("parent post type must not be repost")
+	ErrUserOrPostNotFound   = errors.New("user or post not found")
+	ErrAlreadyLiked         = errors.New("post is already liked")
 )

--- a/go/internal/application/usecase/api/like_post.go
+++ b/go/internal/application/usecase/api/like_post.go
@@ -2,4 +2,7 @@ package api
 
 type LikePostUsecase interface {
 	LikePost(userID string, postID string) error
+
+	SetError(err error)
+	ClearError()
 }

--- a/go/internal/application/usecase/fake/like_post.go
+++ b/go/internal/application/usecase/fake/like_post.go
@@ -1,0 +1,30 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+)
+
+type fakeLikePostUsecase struct {
+	err error
+}
+
+func NewFakeLikePostUsecase() usecase.LikePostUsecase {
+	return &fakeLikePostUsecase{
+		err: nil,
+	}
+}
+
+func (u *fakeLikePostUsecase) LikePost(userID string, postID string) error {
+	if u.err != nil {
+		return u.err
+	}
+	return nil
+}
+
+func (u *fakeLikePostUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeLikePostUsecase) ClearError() {
+	u.err = nil
+}

--- a/go/internal/application/usecase/implementation/like_post.go
+++ b/go/internal/application/usecase/implementation/like_post.go
@@ -1,6 +1,8 @@
 package implementation
 
 import (
+	"errors"
+
 	usecase "x-clone-backend/internal/application/usecase/api"
 	"x-clone-backend/internal/domain/repository"
 )
@@ -15,5 +17,17 @@ func NewLikePostUsecase(usersRepository repository.UsersRepository) usecase.Like
 
 func (u *likePostUsecase) LikePost(userID string, postID string) error {
 	err := u.usersRepository.LikePost(nil, userID, postID)
-	return err
+	if err != nil {
+		if errors.Is(err, repository.ErrForeignViolation) {
+			return usecase.ErrUserOrPostNotFound
+		}
+		if errors.Is(err, repository.ErrUniqueViolation) {
+			return usecase.ErrAlreadyLiked
+		}
+		return err
+	}
+	return nil
 }
+
+func (u *likePostUsecase) SetError(err error) {}
+func (u *likePostUsecase) ClearError()        {}

--- a/go/internal/application/usecase/injector/like_post.go
+++ b/go/internal/application/usecase/injector/like_post.go
@@ -1,11 +1,17 @@
 package injector
 
 import (
+	"testing"
+
 	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
 	"x-clone-backend/internal/application/usecase/implementation"
 	"x-clone-backend/internal/domain/repository"
 )
 
 func InjectLikePostUsecase(usersRepository repository.UsersRepository) usecase.LikePostUsecase {
+	if testing.Testing() {
+		return fake.NewFakeLikePostUsecase()
+	}
 	return implementation.NewLikePostUsecase(usersRepository)
 }

--- a/go/internal/controller/handler/errors.go
+++ b/go/internal/controller/handler/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrDeleteUserFailed     = errors.New("Could not delete a user.")
 	ErrDeletePostFailed     = errors.New("Could not delete a post.")
 	ErrDeleteRepostFailed   = errors.New("Could not delete a repost.")
+	ErrCreateLike           = errors.New("Could not create a like.")
 )
 
 func NewInvalidUserIDError(id string) error {

--- a/go/internal/controller/handler/like_post.go
+++ b/go/internal/controller/handler/like_post.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	usecase "x-clone-backend/internal/application/usecase/api"
@@ -24,16 +23,18 @@ func (h *LikePostHandler) LikePost(w http.ResponseWriter, r *http.Request, userI
 
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&body)
+	// TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/776
+	// - Update OpenAPI Schema to Support More Conditions for LikePost.
 	if err != nil {
-		http.Error(w, fmt.Sprintln("Request body was invalid."), http.StatusBadRequest)
+		http.Error(w, ErrDecodeRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
 
 	err = h.likePostUsecase.LikePost(userID, body.PostId)
 	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not create a like."), http.StatusInternalServerError)
+		http.Error(w, ErrCreateLike.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/openapi/paths/users_userId_likes.yml
+++ b/openapi/paths/users_userId_likes.yml
@@ -14,6 +14,8 @@ post:
       application/json:
         schema:
           $ref: ../components/requestBodies/like_post_request.yml
+  # TODO: https://github.com/okuda-seminar/Twitter-Clone/issues/776
+  # - Update OpenAPI Schema to Support More Conditions for LikePost.
   responses:
     "204":
       description: The post was liked.


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/762

## Implementation Summary
This PR introduces a fake implementation of the `LikePost` use case and adds a corresponding suite of unit tests.

## Scope of Impact
The new unit tests validate the behavior of the `LikePost` API endpoint. They can be executed using the go test command.

## Particular points to check
To ensure compliance with our OpenAPI schema, I've changed the success status code from `w.WriteHeader(http.StatusCreated)` (201) to `w.WriteHeader(http.StatusNoContent) (204)` in the `go/internal/controller/handler/like_post.go`. Please verify this is the correct approach.

## Test
This PR coverage is confirmed by:

`go test ./...`

- Status: 204

<img width="546" alt="Screenshot 2025-06-25 at 12 58 45 AM" src="https://github.com/user-attachments/assets/5084fbea-fa0f-4c6b-91ae-c2bc5f9cee26" />

- Status: 400

<img width="546" alt="Screenshot 2025-06-25 at 1 00 18 AM" src="https://github.com/user-attachments/assets/287b3f28-bf98-47a6-9060-0df78c690188" />


- Status: 500

| Post Already Liked | Post Not Found |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/88d6431a-1472-479e-a264-3345e2f8f162" width="400"> | <img src="https://github.com/user-attachments/assets/78494ae4-18a8-43b1-a477-32be29a0f736" width="400"> |

## Schedule
7/5