### PR TITLE
[Go] Write tests in FindUserByID

### DIFF
--- a/go/internal/application/usecase/api/user_by_user_id.go
+++ b/go/internal/application/usecase/api/user_by_user_id.go
@@ -6,4 +6,8 @@ import (
 
 type UserByUserIDUsecase interface {
 	UserByUserID(userID string) (entity.User, error)
+
+	SetError(err error)
+	ClearError()
+	SetUser(entity.User)
 }

--- a/go/internal/application/usecase/fake/user_by_user_id.go
+++ b/go/internal/application/usecase/fake/user_by_user_id.go
@@ -1,0 +1,37 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/domain/entity"
+)
+
+type fakeUserByUserIDUsecase struct {
+	err  error
+	user entity.User
+}
+
+func NewFakeUserByUserIDUsecase() usecase.UserByUserIDUsecase {
+	return &fakeUserByUserIDUsecase{
+		err:  nil,
+		user: entity.User{},
+	}
+}
+
+func (u *fakeUserByUserIDUsecase) UserByUserID(userID string) (entity.User, error) {
+	if u.err != nil {
+		return entity.User{}, u.err
+	}
+	return u.user, nil
+}
+
+func (u *fakeUserByUserIDUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeUserByUserIDUsecase) ClearError() {
+	u.err = nil
+}
+
+func (u *fakeUserByUserIDUsecase) SetUser(user entity.User) {
+	u.user = user
+}

--- a/go/internal/application/usecase/implementation/user_by_user_id.go
+++ b/go/internal/application/usecase/implementation/user_by_user_id.go
@@ -22,3 +22,7 @@ func (u *userByUserIDUsecase) UserByUserID(userID string) (entity.User, error) {
 
 	return user, nil
 }
+
+func (u *userByUserIDUsecase) SetError(err error)  {}
+func (u *userByUserIDUsecase) ClearError()         {}
+func (u *userByUserIDUsecase) SetUser(entity.User) {}

--- a/go/internal/application/usecase/injector/user_by_user_id.go
+++ b/go/internal/application/usecase/injector/user_by_user_id.go
@@ -1,11 +1,17 @@
 package injector
 
 import (
+	"testing"
+
 	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
 	"x-clone-backend/internal/application/usecase/implementation"
 	"x-clone-backend/internal/domain/repository"
 )
 
 func InjectUserByUserIDUsecase(usersRepository repository.UsersRepository) usecase.UserByUserIDUsecase {
+	if testing.Testing() {
+		return fake.NewFakeUserByUserIDUsecase()
+	}
 	return implementation.NewUserByUserIDUsecase(usersRepository)
 }

--- a/go/internal/controller/handler/errors.go
+++ b/go/internal/controller/handler/errors.go
@@ -23,8 +23,14 @@ var (
 	ErrDeletePostFailed     = errors.New("Could not delete a post.")
 	ErrDeleteRepostFailed   = errors.New("Could not delete a repost.")
 	ErrCreateLike           = errors.New("Could not create a like.")
+	ErrInvalidToken         = errors.New("Invalid or expired token.")
+	ErrInternalError        = errors.New("Unexpected error occurred.")
 )
 
 func NewInvalidUserIDError(id string) error {
 	return fmt.Errorf("Could not parse a userID (ID: %s).", id)
+}
+
+func NewUserNotFoundError(userID string) error {
+	return fmt.Errorf("Could not find a user (ID: %s).", userID)
 }

--- a/go/internal/controller/handler/find_user_by_id.go
+++ b/go/internal/controller/handler/find_user_by_id.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
-	"log/slog"
 	"net/http"
 
 	usecase "x-clone-backend/internal/application/usecase/api"
@@ -22,11 +20,10 @@ func NewFindUserByIDHandler(userByUserIDUsecase usecase.UserByUserIDUsecase) Fin
 
 // FindUserByID finds a user with the specified ID.
 func (h *FindUserByIDHandler) FindUserByID(w http.ResponseWriter, r *http.Request, userID string) {
-	slog.Info("GET /api/users/{userID} was called.")
 
 	user, err := h.userByUserIDUsecase.UserByUserID(userID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not find a user (ID: %s)\n", userID), http.StatusNotFound)
+		http.Error(w, NewUserNotFoundError(userID).Error(), http.StatusNotFound)
 		return
 	}
 	res := transfer.ToFindUserByIDResponse(&user)
@@ -37,7 +34,7 @@ func (h *FindUserByIDHandler) FindUserByID(w http.ResponseWriter, r *http.Reques
 	encoder := json.NewEncoder(w)
 	err = encoder.Encode(res)
 	if err != nil {
-		http.Error(w, fmt.Sprintln("Could not encode response."), http.StatusInternalServerError)
+		http.Error(w, ErrEncodeResponse.Error(), http.StatusInternalServerError)
 		return
 	}
 }

--- a/go/internal/controller/handler/find_user_by_id_test.go
+++ b/go/internal/controller/handler/find_user_by_id_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	usecase "x-clone-backend/internal/application/usecase/api"
+	usecaseInjector "x-clone-backend/internal/application/usecase/injector"
+)
+
+func TestFindUserByID(t *testing.T) {
+	existingUserID := uuid.NewString()
+	nonExistentUserID := uuid.NewString()
+
+	tests := map[string]struct {
+		userID       string
+		setup        func(userByUserIDUsecase usecase.UserByUserIDUsecase)
+		expectedCode int
+	}{
+		"returns 200 when user exists": {
+			userID:       existingUserID,
+			expectedCode: http.StatusOK,
+		},
+		"returns 404 when user does not exist": {
+			userID: nonExistentUserID,
+			setup: func(userByUserIDUsecase usecase.UserByUserIDUsecase) {
+				userByUserIDUsecase.SetError(usecase.ErrUserNotFound)
+			},
+			expectedCode: http.StatusNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			userByUserIDUsecase := usecaseInjector.InjectUserByUserIDUsecase(nil)
+			findUserByIDHandler := NewFindUserByIDHandler(userByUserIDUsecase)
+
+			if tt.setup != nil {
+				tt.setup(userByUserIDUsecase)
+			}
+
+			req := httptest.NewRequest(
+				"GET",
+				fmt.Sprintf("/api/users/%s", tt.userID),
+				nil,
+			)
+			rr := httptest.NewRecorder()
+
+			findUserByIDHandler.FindUserByID(rr, req, tt.userID)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("%s: wrong code returned; expected %d, but got %d", name, tt.expectedCode, rr.Code)
+			}
+		})
+	}
+}

--- a/go/internal/controller/handler/verify_session.go
+++ b/go/internal/controller/handler/verify_session.go
@@ -24,19 +24,19 @@ func NewVerifySessionHandler(authService *service.AuthService, userByUserIDUseca
 func (h *VerifySessionHandler) VerifySession(w http.ResponseWriter, r *http.Request) {
 	token, err := service.ExtractTokenFromHeader(r)
 	if err != nil {
-		http.Error(w, "Invalid or expired token.", http.StatusUnauthorized)
+		http.Error(w, ErrInvalidToken.Error(), http.StatusUnauthorized)
 		return
 	}
 
 	userID, err := h.authService.ValidateJWT(token)
 	if err != nil {
-		http.Error(w, "Invalid or expired token.", http.StatusUnauthorized)
+		http.Error(w, ErrInvalidToken.Error(), http.StatusUnauthorized)
 		return
 	}
 
 	user, err := h.userByUserIDUsecase.UserByUserID(userID)
 	if err != nil {
-		http.Error(w, "Unexpected error occurred.", http.StatusInternalServerError)
+		http.Error(w, ErrInternalError.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -46,7 +46,7 @@ func (h *VerifySessionHandler) VerifySession(w http.ResponseWriter, r *http.Requ
 	encoder := json.NewEncoder(w)
 	err = encoder.Encode(res)
 	if err != nil {
-		http.Error(w, "Unexpected error occurred.", http.StatusInternalServerError)
+		http.Error(w, ErrInternalError.Error(), http.StatusInternalServerError)
 		return
 	}
 }


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/779

## Implementation Summary
This PR introduces a fake implementation of the `UserByUserID` use case and adds a corresponding suite of unit tests.

## Scope of Impact
The new unit tests validate the behavior of the `FindUserByID` API endpoint. They can be executed using the go test command.
By implementing a fake for userByUserID, I also made changes to verify_session_test.go, which was using InjectUserByUserIDUsecase.

## Test
`go test ./...`

## Schedule
7/11
