### PR TITLE
[Go] refactor unlikePost test

### DIFF
--- a/go/internal/application/usecase/api/unlike_post.go
+++ b/go/internal/application/usecase/api/unlike_post.go
@@ -2,4 +2,6 @@ package api
 
 type UnlikePostUsecase interface {
 	UnlikePost(userID string, postID string) error
+	SetError(err error)
+	ClearError()
 }

--- a/go/internal/application/usecase/fake/unlike_post.go
+++ b/go/internal/application/usecase/fake/unlike_post.go
@@ -1,0 +1,30 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+)
+
+type fakeUnlikePostUsecase struct {
+	err error
+}
+
+func NewFakeUnlikePostUsecase() usecase.UnlikePostUsecase {
+	return &fakeUnlikePostUsecase{
+		err: nil,
+	}
+}
+
+func (u *fakeUnlikePostUsecase) UnlikePost(userID, postID string) error {
+	if u.err != nil {
+		return u.err
+	}
+	return nil
+}
+
+func (u *fakeUnlikePostUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeUnlikePostUsecase) ClearError() {
+	u.err = nil
+}

--- a/go/internal/application/usecase/implementation/unlike_post.go
+++ b/go/internal/application/usecase/implementation/unlike_post.go
@@ -23,3 +23,6 @@ func (u *unlikePostUsecase) UnlikePost(userID string, postID string) error {
 
 	return err
 }
+
+func (u *unlikePostUsecase) SetError(err error) {}
+func (u *unlikePostUsecase) ClearError()        {}

--- a/go/internal/application/usecase/injector/unlike_post.go
+++ b/go/internal/application/usecase/injector/unlike_post.go
@@ -1,12 +1,18 @@
 package injector
 
 import (
+	"testing"
+
 	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
 	"x-clone-backend/internal/application/usecase/implementation"
 	"x-clone-backend/internal/domain/repository"
 )
 
 func InjectUnlikePostUsecase(usersRepository repository.UsersRepository) usecase.UnlikePostUsecase {
+	if testing.Testing() {
+		return fake.NewFakeUnlikePostUsecase()
+	}
 	return implementation.NewUnlikePostUsecase(usersRepository)
 
 }

--- a/go/internal/controller/handler/errors.go
+++ b/go/internal/controller/handler/errors.go
@@ -30,6 +30,8 @@ var (
 	ErrSetChannel             = errors.New("Failed to set notification channel")
 	ErrUserAndFolloweePosts   = errors.New("Could not get timelineitems")
 	ErrCreateMuting           = errors.New("Could not create muting")
+	ErrLikeNotFound           = errors.New("No row found to delete")
+	ErrDeleteLike             = errors.New("Could not delete a like.")
 )
 
 func NewInvalidUserIDError(id string) error {

--- a/go/internal/controller/handler/unlike_post.go
+++ b/go/internal/controller/handler/unlike_post.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	usecase "x-clone-backend/internal/application/usecase/api"
@@ -23,9 +22,9 @@ func (h *UnlikePostHandler) UnlikePost(w http.ResponseWriter, r *http.Request, u
 	if err != nil {
 		switch {
 		case errors.Is(err, usecase.ErrLikeNotFound):
-			http.Error(w, "No row found to delete", http.StatusNotFound)
+			http.Error(w, ErrLikeNotFound.Error(), http.StatusNotFound)
 		default:
-			http.Error(w, fmt.Sprintf("Could not delete a like: %v", err), http.StatusInternalServerError)
+			http.Error(w, ErrDeleteLike.Error(), http.StatusInternalServerError)
 		}
 		return
 	}

--- a/go/internal/controller/handler/unlike_post_test.go
+++ b/go/internal/controller/handler/unlike_post_test.go
@@ -1,60 +1,72 @@
 package handler
 
-// func (s *handlerTestSuite) TestUnlikePost() {
-// 	// UnlikePost must use existing user ID and post ID
-// 	// from the users and posts table.
-// 	// Therefore, users and posts are created
-// 	// for testing purposes to obtain these IDs.
-// 	userID := s.newTestUser(`{ "username": "user", "display_name": "user", "password": "securepassword" }`)
-// 	postID := s.newTestPost(fmt.Sprintf(`{ "user_id": "%s", "text": "test post" }`, userID))
-// 	s.newTestLike(userID, postID)
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-// 	tests := []struct {
-// 		name         string
-// 		userID       string
-// 		postID       string
-// 		expectedCode int
-// 	}{
-// 		{
-// 			name:         "unlike a post successfully with a proper pair of User and Post.",
-// 			userID:       userID,
-// 			postID:       postID,
-// 			expectedCode: http.StatusNoContent,
-// 		},
-// 		{
-// 			name:         "fail to unlike a post with a pair of non-existent User and proper Post.",
-// 			userID:       uuid.New().String(),
-// 			postID:       postID,
-// 			expectedCode: http.StatusNotFound,
-// 		},
-// 		{
-// 			name:         "fail to unlike a post with a pair of proper User and non-existent Post.",
-// 			userID:       userID,
-// 			postID:       uuid.New().String(),
-// 			expectedCode: http.StatusNotFound,
-// 		},
-// 	}
+	"github.com/google/uuid"
 
-// 	for _, test := range tests {
-// 		req := httptest.NewRequest(
-// 			"DELETE",
-// 			"/api/users/{id}/likes/{post_id}",
-// 			strings.NewReader(""),
-// 		)
-// 		req.SetPathValue("id", test.userID)
-// 		req.SetPathValue("post_id", test.postID)
+	usecase "x-clone-backend/internal/application/usecase/api"
+	usecaseInjector "x-clone-backend/internal/application/usecase/injector"
+)
 
-// 		rr := httptest.NewRecorder()
-// 		UnlikePost(rr, req, s.unlikePostUsecase)
+func TestUnlikePost(t *testing.T) {
+	userID := uuid.NewString()
+	postID := uuid.NewString()
 
-// 		if rr.Code != test.expectedCode {
-// 			s.T().Errorf(
-// 				"%s: wrong code returned; expected %d, but got %d",
-// 				test.name,
-// 				test.expectedCode,
-// 				rr.Code,
-// 			)
-// 		}
+	tests := map[string]struct {
+		userID       string
+		postID       string
+		setup        func(unlikePostUsecase usecase.UnlikePostUsecase)
+		expectedCode int
+	}{
+		"returns 204 when a user unlikes a post successfully": {
+			userID:       userID,
+			postID:       postID,
+			expectedCode: http.StatusNoContent,
+		},
+		"returns 500 when there is a server error": {
+			userID: uuid.NewString(),
+			postID: postID,
+			setup: func(unlikePostUsecase usecase.UnlikePostUsecase) {
+				unlikePostUsecase.SetError(fmt.Errorf("unexpected error"))
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		"returns 404 when user exists and post does not exist": {
+			userID: userID,
+			postID: uuid.NewString(),
+			setup: func(unlikePostUsecase usecase.UnlikePostUsecase) {
+				unlikePostUsecase.SetError(usecase.ErrLikeNotFound)
+			},
+			expectedCode: http.StatusNotFound,
+		},
+	}
 
-// 	}
-// }
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			unlikePostUsecase := usecaseInjector.InjectUnlikePostUsecase(nil)
+			unlikePostHandler := NewUnlikePostHandler(unlikePostUsecase)
+
+			if tt.setup != nil {
+				tt.setup(unlikePostUsecase)
+			}
+
+			req := httptest.NewRequest(
+				"DELETE",
+				fmt.Sprintf("/api/users/%s/likes/%s", tt.userID, tt.postID),
+				strings.NewReader(""),
+			)
+			rr := httptest.NewRecorder()
+
+			unlikePostHandler.UnlikePost(rr, req, tt.userID, tt.postID)
+
+			if rr.Code != tt.expectedCode {
+				t.Errorf("%s: wrong code returned; expected %d, but got %d", name, tt.expectedCode, rr.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/790

## Implementation Summary
This PR introduces a fake implementation of the `UnlikePost` use case and adds a corresponding suite of unit tests.

## Scope of Impact
The new unit tests validate the behavior of the `UnlikePost` API endpoint. They can be executed using the go test command.

## Particular points to check
- Whether the implementation of the fake is correct
- Whether the test cases are sufficient
- Whether the status codes are being checked correctly

## Test
`testUnlikePost` checks if the handlers return the expected status code.

## Schedule
08/09
