### PR TITLE
[Go] Write tests in MuteUser

### DIFF
--- a/go/internal/application/usecase/api/mute_user.go
+++ b/go/internal/application/usecase/api/mute_user.go
@@ -2,4 +2,7 @@ package api
 
 type MuteUserUsecase interface {
 	MuteUser(sourceUserID, targetUserID string) error
+
+	SetError(err error)
+	ClearError()
 }

--- a/go/internal/application/usecase/fake/mute_user.go
+++ b/go/internal/application/usecase/fake/mute_user.go
@@ -1,0 +1,30 @@
+package fake
+
+import (
+	usecase "x-clone-backend/internal/application/usecase/api"
+)
+
+type fakeMuteUserUsecase struct {
+	err error
+}
+
+func NewFakeMuteUserUsecase() usecase.MuteUserUsecase {
+	return &fakeMuteUserUsecase{
+		err: nil,
+	}
+}
+
+func (u *fakeMuteUserUsecase) MuteUser(sourceUserID, targetUserID string) error {
+	if u.err != nil {
+		return u.err
+	}
+	return nil
+}
+
+func (u *fakeMuteUserUsecase) SetError(err error) {
+	u.err = err
+}
+
+func (u *fakeMuteUserUsecase) ClearError() {
+	u.err = nil
+}

--- a/go/internal/application/usecase/implementation/mute_user.go
+++ b/go/internal/application/usecase/implementation/mute_user.go
@@ -17,3 +17,6 @@ func (u *muteUserUsecase) MuteUser(sourceUserID, targetUserID string) error {
 	err := u.usersRepository.MuteUser(nil, sourceUserID, targetUserID)
 	return err
 }
+
+func (u *muteUserUsecase) SetError(err error) {}
+func (u *muteUserUsecase) ClearError()        {}

--- a/go/internal/application/usecase/injector/mute_user.go
+++ b/go/internal/application/usecase/injector/mute_user.go
@@ -1,11 +1,17 @@
 package injector
 
 import (
+	"testing"
+
 	usecase "x-clone-backend/internal/application/usecase/api"
+	"x-clone-backend/internal/application/usecase/fake"
 	"x-clone-backend/internal/application/usecase/implementation"
 	"x-clone-backend/internal/domain/repository"
 )
 
 func InjectMuteUserUsecase(usersRepository repository.UsersRepository) usecase.MuteUserUsecase {
+	if testing.Testing() {
+		return fake.NewFakeMuteUserUsecase()
+	}
 	return implementation.NewMuteUserUsecase(usersRepository)
 }

--- a/go/internal/controller/handler/errors.go
+++ b/go/internal/controller/handler/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrCreateBlock            = errors.New("Could not create a block.")
 	ErrSetChannel             = errors.New("Failed to set notification channel")
 	ErrUserAndFolloweePosts   = errors.New("Could not get timelineitems")
+	ErrCreateMuting           = errors.New("Could not create muting")
 )
 
 func NewInvalidUserIDError(id string) error {

--- a/go/internal/controller/handler/mute_user.go
+++ b/go/internal/controller/handler/mute_user.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	usecase "x-clone-backend/internal/application/usecase/api"
@@ -25,13 +24,13 @@ func (h *MuteUserHandler) MuteUser(w http.ResponseWriter, r *http.Request, userI
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&body)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Request body was invalid: %v", err), http.StatusBadRequest)
+		http.Error(w, ErrDecodeRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
 
 	err = h.muteUserUsecase.MuteUser(userID, body.TargetUserId)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not create muting: %v", err), http.StatusInternalServerError)
+		http.Error(w, ErrCreateMuting.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
## Issue Number
https://github.com/okuda-seminar/Twitter-Clone/issues/795

## Implementation Summary
This PR introduces a fake implementation of the MuteUser use case and adds a corresponding suite of unit tests.
The handler only handles JSON decoding errors (400) and usecase execution errors (500), so I implemented tests for 201 (success) and 500 (error) scenarios only.

## Scope of Impact
The new unit tests validate the behavior of the MuteUser API endpoint. They can be executed using the go test command.


## Test
`go test ./...`

## Schedule
8/1
