### PR TITLE
[Go] Reflect createPost in cache

### DIFF
--- a/go/internal/application/usecase/injector/create_post.go
+++ b/go/internal/application/usecase/injector/create_post.go
@@ -6,6 +6,6 @@ import (
 	"x-clone-backend/internal/domain/repository"
 )
 
-func InjectCreatePostUsecase(timelineItemsRepository repository.TimelineItemsRepository) usecase.CreatePostUsecase {
-	return implementation.NewCreatePostUsecase(timelineItemsRepository)
+func InjectCreatePostUsecase(timelineItemsRepository repository.TimelineItemsRepository, usersRepository repository.UsersRepository) usecase.CreatePostUsecase {
+	return implementation.NewCreatePostUsecase(timelineItemsRepository, usersRepository)
 }

--- a/go/internal/controller/handler/create_post_test.go
+++ b/go/internal/controller/handler/create_post_test.go
@@ -51,7 +51,7 @@ func TestCreatePost(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			timelineItemsRepository := infraInjector.InjectTimelineItemsRepository(nil, nil)
 			usersRepository := infraInjector.InjectUsersRepository(nil)
-			createPostUsecase := usecaseInjector.InjectCreatePostUsecase(timelineItemsRepository)
+			createPostUsecase := usecaseInjector.InjectCreatePostUsecase(timelineItemsRepository, usersRepository)
 			updateNotificationUsecase := usecaseInjector.InjectUpdateNotificationUsecase(usersRepository)
 			createPostHandler := NewCreatePostHandler(updateNotificationUsecase, createPostUsecase)
 

--- a/go/internal/controller/handler/create_quote_repost_test.go
+++ b/go/internal/controller/handler/create_quote_repost_test.go
@@ -106,12 +106,12 @@ func TestCreateQuoteRepost(t *testing.T) {
 
 			switch tt.parentPostType {
 			case entity.PostTypePost:
-				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText)
+				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText, []string{})
 				if err != nil {
 					t.Errorf("Failed to create a post")
 				}
 			case entity.PostTypeQuoteRepost:
-				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText)
+				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText, []string{})
 				if err != nil {
 					t.Errorf("Failed to create a post")
 				}
@@ -120,7 +120,7 @@ func TestCreateQuoteRepost(t *testing.T) {
 					t.Errorf("Failed to create a quote repost")
 				}
 			case entity.PostTypeRepost:
-				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText)
+				parentPost, err = timelineItemsRepository.CreatePost(postUserID, postText, []string{})
 				if err != nil {
 					t.Errorf("Failed to create a post")
 				}

--- a/go/internal/controller/handler/get_post_by_post_id_test.go
+++ b/go/internal/controller/handler/get_post_by_post_id_test.go
@@ -20,14 +20,14 @@ func TestGetPostByPostID(t *testing.T) {
 	}{
 		"successfully get the specified post": {
 			setupPost: func(timelineItemsRepository repository.TimelineItemsRepository) string {
-				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test")
+				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test", []string{})
 				return post.ID
 			},
 			expectedCode: http.StatusOK,
 		},
 		"successfully get the specified repost": {
 			setupPost: func(timelineItemsRepository repository.TimelineItemsRepository) string {
-				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test")
+				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test", []string{})
 				repost, _ := timelineItemsRepository.CreateRepost(uuid.NewString(), post.ID)
 				return repost.ID
 			},
@@ -35,7 +35,7 @@ func TestGetPostByPostID(t *testing.T) {
 		},
 		"successfully get the specified quote repost": {
 			setupPost: func(timelineItemsRepository repository.TimelineItemsRepository) string {
-				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test")
+				post, _ := timelineItemsRepository.CreatePost(uuid.NewString(), "test", []string{})
 				quoteRepost, _ := timelineItemsRepository.CreateQuoteRepost(uuid.NewString(), post.ID, "quote repost")
 				return quoteRepost.ID
 			},

--- a/go/internal/controller/server.go
+++ b/go/internal/controller/server.go
@@ -50,7 +50,7 @@ func NewServer(db *sql.DB, client *redis.Client) Server {
 	authService := service.NewAuthService(secretKey)
 
 	blockUserUsecase := usecaseInjector.InjectBlockUserUsecase(usersRepository)
-	createPostUsecase := usecaseInjector.InjectCreatePostUsecase(timelineItemsRepository)
+	createPostUsecase := usecaseInjector.InjectCreatePostUsecase(timelineItemsRepository, usersRepository)
 	createQuoteRepostUsecase := usecaseInjector.InjectCreateQuoteRepostUsecase(timelineItemsRepository)
 	createRepostUsecase := usecaseInjector.InjectCreateRepostUsecase(timelineItemsRepository)
 	createUserUsecase := usecaseInjector.InjectCreateUserUsecase(usersRepository)

--- a/go/internal/domain/repository/timeline_items.go
+++ b/go/internal/domain/repository/timeline_items.go
@@ -5,7 +5,7 @@ import "x-clone-backend/internal/domain/entity"
 type TimelineItemsRepository interface {
 	SpecificUserPosts(userID string) ([]*entity.TimelineItem, error)
 	UserAndFolloweePosts(userID string) ([]*entity.TimelineItem, error)
-	CreatePost(userID, text string) (entity.TimelineItem, error)
+	CreatePost(userID, text string, userIDs []string) (entity.TimelineItem, error)
 	DeletePost(postID string) (entity.TimelineItem, error)
 	CreateRepost(userID, postID string) (entity.TimelineItem, error)
 	DeleteRepost(postID string) (entity.TimelineItem, error)

--- a/go/internal/infrastructure/cache/timeline_items.go
+++ b/go/internal/infrastructure/cache/timeline_items.go
@@ -1,6 +1,10 @@
 package cache
 
 import (
+	"context"
+	"fmt"
+	"log"
+
 	"github.com/redis/go-redis/v9"
 )
 
@@ -12,4 +16,29 @@ func NewcacheTimelineItemsRepository(client *redis.Client) CacheTimelineItemsRep
 	return CacheTimelineItemsRepository{
 		client: client,
 	}
+}
+
+func (c *CacheTimelineItemsRepository) CreatePost(postID string, userIDs []string, timestamp float64) error {
+	ctx := context.Background()
+	_, err := c.client.Pipelined(ctx, func(p redis.Pipeliner) error {
+		for _, userID := range userIDs {
+			p.ZAdd(ctx, fmt.Sprintf("timeline:%s", userID), redis.Z{Score: timestamp, Member: postID})
+		}
+		return nil
+	})
+	if err != nil {
+		_, err := c.client.Pipelined(ctx, func(p redis.Pipeliner) error {
+			for _, userID := range userIDs {
+				p.ZRem(ctx, fmt.Sprintf("timeline:%s", userID), postID)
+			}
+			return nil
+		})
+		if err != nil {
+			log.Println("Failed to rollback cache after CreatePost error:", err)
+			log.Println("The following users' timelines are inconsistent", userIDs)
+			return err
+		}
+	}
+
+	return err
 }

--- a/go/internal/infrastructure/fake/timeline_items.go
+++ b/go/internal/infrastructure/fake/timeline_items.go
@@ -70,7 +70,7 @@ func (r *fakeTimelineitemsRepository) UserAndFolloweePosts(userID string) ([]*en
 // CreatePost creates and stores a new post by the given userID with the provided text in the in-memory database.
 // If a preconfigured error for CreatePost exists, it returns the error without creating a post.
 // Otherwise, it returns the created TimelineItem.
-func (r *fakeTimelineitemsRepository) CreatePost(userID string, text string) (entity.TimelineItem, error) {
+func (r *fakeTimelineitemsRepository) CreatePost(userID string, text string, userIDs []string) (entity.TimelineItem, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 


### PR DESCRIPTION
## Issue Number
#844 

## Implementation Summary
Same with the title

## Scope of Impact
I added an argument, usersID, which is used for `cacheRepository`, to the `CreatePost` method in the `timelineItemsRepository`.

## Particular points to check
If my modification is acceptable.
I considered introducing an application service and treating the cache and RDB as completely separate repositories. However, since the previous PR was designed both as concrete classes of the timelineItemsRepository, I chose to increase the number of arguments passed to the `CreatePost` method in the `timelineItemsRepository`.

## Test
I manually tested the following items.
- When a post is posted, the postID is reflected in the user's timeline in the cache.
I added the following code after the pipelined insertion to Redis
```go
_, err := c.client.Pipelined(ctx, func(p redis.Pipeliner) error {
  for _, userID := range userIDs {
	  p.ZAdd(ctx, fmt.Sprintf("timeline:%s", userID), redis.Z{Score: timestamp, Member: postID})
  }
  return nil
  })
  if err != nil {
  _, err := c.client.Pipelined(ctx, func(p redis.Pipeliner) error {
	  for _, userID := range userIDs {
		  p.ZRem(ctx, fmt.Sprintf("timeline:%s", userID), postID)
	  }
	  return nil
  })
  if err != nil {
	  log.Println("Failed to rollback cache after CreatePost error:", err)
	  return err
  }
}
for _, userID := range userIDs {
  zAddRes, err := c.client.ZRangeWithScores(ctx, userID, 0, -1).Result()
    if err != nil {
	    return err
    }
  fmt.Println(zAddRes)
}
```
## Notes
Currently, the `getFollowers` handler implementation is in progress.  This PR will be merged after the temporary parent branch feature/#819_complete_get_followers_by_id_implementation is merged.
## Schedule
10/3
